### PR TITLE
fix(examples): compile issue

### DIFF
--- a/examples/optimizer.cpp
+++ b/examples/optimizer.cpp
@@ -9,6 +9,7 @@
 //============================================================================
 
 #include "ibex.h"
+#include <sstream>
 
 using namespace std;
 using namespace ibex;

--- a/examples/robust_estim1.cpp
+++ b/examples/robust_estim1.cpp
@@ -1,11 +1,13 @@
 
 #include "ibex.h"
+#include "ibex_Random.h"
 
 #include <iostream>
 #include <stdlib.h>
 #include <ctime>
 
 using namespace std;
+using ibex::RNG;
 
 /*================== data =================*/
 const bool qinteronly=false;  // do we use q-intersection alone, or fixedpoint ?

--- a/examples/robust_estim4.cpp
+++ b/examples/robust_estim4.cpp
@@ -1,11 +1,13 @@
 
 #include "ibex.h"
+#include "ibex_Random.h"
 
 #include <iostream>
 #include <stdlib.h>
 #include <ctime>
 
 using namespace std;
+using ibex::RNG;
 
 /*
  * 

--- a/examples/solver.cpp
+++ b/examples/solver.cpp
@@ -1,4 +1,5 @@
 #include "ibex.h"
+#include <sstream>
 
 using namespace std;
 using namespace ibex;


### PR DESCRIPTION
Dear ibex-team,

To compile files under `examples` directory, I had to make this change. Actually, I still have one error on `examples/TestHeap.cpp` file. Other than that, this patch helped me compile other files.

```
/usr0/home/soonhok/work/dreal3/build/release-clang/include/ibex/ibex_CellDoubleHeap.h:90:8: note: ibex::CellDoubleHeap::CellDoubleHeap(ibex::CellCostFunc&, ibex::CellCostFunc&, int)
/usr0/home/soonhok/work/dreal3/build/release-clang/include/ibex/ibex_CellDoubleHeap.h:90:8: note:   candidate expects 3 arguments, 1 provided
/usr0/home/soonhok/work/dreal3/build/release-clang/include/ibex/ibex_CellDoubleHeap.h:25:7: note: ibex::CellDoubleHeap::CellDoubleHeap(const ibex::CellDoubleHeap&)
/usr0/home/soonhok/work/dreal3/build/release-clang/include/ibex/ibex_CellDoubleHeap.h:25:7: note:   no known conversion for argument 1 from ‘int’ to ‘const ibex::CellDoubleHeap&’
```