### PR TITLE
fix(tests/nonreg.cpp): add missing <iomanip> header

### DIFF
--- a/tests/nonreg.cpp
+++ b/tests/nonreg.cpp
@@ -9,6 +9,7 @@
 
 #include "ibex.h"
 #include <fstream>
+#include <iomanip>
 #include <sstream>
 #include <stdlib.h>
 


### PR DESCRIPTION
clang generates an error without this header.