### PR TITLE
Interval <-> char* conversion

### DIFF
--- a/src/tools/ibex_String.cpp
+++ b/src/tools/ibex_String.cpp
@@ -1,15 +1,16 @@
 //============================================================================
 //                                  I B E X                                   
 // File        : ibex_String.cpp
-// Author      : Gilles Chabert
+// Author      : Gilles Chabert, Simon Rohou
 // Copyright   : Ecole des Mines de Nantes (France)
 // License     : See the LICENSE file
 // Created     : Jul 18, 2012
-// Last Update : Jul 18, 2012
+// Last Update : April 18, 2016
 //============================================================================
 
 #include "ibex_String.h"
 #include <stdlib.h>
+#include <sstream>
 
 namespace ibex {
 
@@ -58,5 +59,59 @@ char* next_generated_func_name() {
 	return next_generated_name(BASE_FUNC_NAME,generated_func_count++);
 }
 
+const char* intv2str(const Interval& intv, int precision) {
+  std::ostringstream o;
+
+  if(intv == Interval::EMPTY_SET ||
+     intv == Interval::POS_REALS ||
+     intv == Interval::NEG_REALS ||
+     intv == Interval::ALL_REALS)
+  {
+    o << intv;
+  }
+
+  else
+  {
+    if(precision == -1)
+      o << intv;
+
+    else
+    {
+      o.precision(precision);
+      o << "[" << (double)intv.lb() << ", " << (double)intv.ub() << "]";
+    }
+  }
+
+  return o.str().c_str();
+}
+
+const Interval str2intv(const char* str) {
+  std::string s = str;
+
+  if(s.find(intv2str(Interval::EMPTY_SET)) != std::string::npos)
+    return Interval::EMPTY_SET;
+
+  else if(s.find(intv2str(Interval::POS_REALS)) != std::string::npos)
+    return Interval::POS_REALS;
+
+  else if(s.find(intv2str(Interval::NEG_REALS)) != std::string::npos)
+    return Interval::NEG_REALS;
+
+  else if(s.find(intv2str(Interval::ALL_REALS)) != std::string::npos)
+    return Interval::ALL_REALS;
+
+  else { // string of the form "[float_lb,float_ub]"
+    // Removing unwanted spaces:
+    s.erase(std::remove(s.begin(), s.end(), ' '), s.end());
+
+    std::string delimiter = ",";
+    size_t pos_delimiter = s.find(',');
+    std::string lb = s.substr(1, s.find(delimiter) - delimiter.length());
+    std::string ub = s.substr(lb.length() + 2,
+                              s.length() - lb.length() - delimiter.length()  - 2);
+
+    return Interval(atof(lb.c_str()), atof(ub.c_str()));
+  }
+}
 
 } // end namespace ibex

--- a/src/tools/ibex_String.h
+++ b/src/tools/ibex_String.h
@@ -1,11 +1,11 @@
 //============================================================================
 //                                  I B E X                                   
 // File        : ibex_String.h
-// Author      : Gilles Chabert
+// Author      : Gilles Chabert, Simon Rohou
 // Copyright   : Ecole des Mines de Nantes (France)
 // License     : See the LICENSE file
 // Created     : Jul 18, 2012
-// Last Update : Jul 18, 2012
+// Last Update : April 18, 2016
 //============================================================================
 
 #ifndef __IBEX_STRING_H_
@@ -14,6 +14,7 @@
 #include <cassert>
 #include <string.h>
 #include <stdio.h>
+#include "ibex_Interval.h"
 
 namespace ibex {
 
@@ -39,6 +40,28 @@ char* next_generated_var_name();
  * \brief Generate a function name (_f_i).
  */
 char* next_generated_func_name();
+
+/**
+ * \brief Casts an Interval object into a C string.
+ *
+ * \param the Interval object to parse
+ * \param precision number of digits to display, default: use of operator<< precision
+ * 
+ * \return the corresponding C string, e.g.: "[-0.215,53.2]" or "[ empty ]"
+ */
+const char* intv2str(const Interval& intv, int precision = -1);
+
+/**
+ * \brief Parses the C string str, interpreting its content as
+ * an interval and returns the corresponding object.
+ *
+ * Note: unwanted spaces are removed before cast.
+ *
+ * \param str C string, e.g.: "[-0.215,53.2]" or "[ empty ]"
+ * 
+ * \return the corresponding Interval object
+ */
+const Interval str2intv(const char* str);
 
 } // end namespace ibex
 #endif // __IBEX_STRING_H__

--- a/tests/TestString.cpp
+++ b/tests/TestString.cpp
@@ -5,8 +5,9 @@
  * License     : This program can be distributed under the terms of the GNU LGPL.
  *               See the file COPYING.LESSER.
  *
- * Author(s)   : Gilles Chabert
+ * Author(s)   : Gilles Chabert, Simon Rohou
  * Created     : Mar 2, 2012
+ * Updated     : April 18, 2016
  * ---------------------------------------------------------------------------- */
 
 #include "TestString.h"
@@ -28,6 +29,28 @@ void TestString::test02() {
 	CPPUNIT_ASSERT(strcmp(buf,"bar{0}")==0);
 	CPPUNIT_ASSERT(strlen(buf)==6);
 	free(buf);
+}
+
+bool testConversion(const Interval& intv, int precision)
+{
+	// Adding unwanted spaces:
+	string str_intv = "  " + string(intv2str(intv, precision)) + "  ";
+	Interval intv_parsed = str2intv(str_intv.c_str());
+	return intv_parsed == intv ||
+					fabs(intv_parsed.lb() - intv.lb()) < 1.0e-1 && fabs(intv_parsed.ub() - intv.ub()) < 1.0e-1;
+}
+
+void TestString::test03() {
+	CPPUNIT_ASSERT(testConversion(Interval(-6.3588151,2.864632), 4));
+	CPPUNIT_ASSERT(testConversion(Interval(0,27885.5523), 15));
+	CPPUNIT_ASSERT(testConversion(Interval(-99,-97), 7));
+	CPPUNIT_ASSERT(testConversion(Interval::EMPTY_SET, 4));
+	CPPUNIT_ASSERT(testConversion(Interval::ALL_REALS, 4));
+	CPPUNIT_ASSERT(testConversion(Interval::ZERO, 4));
+	CPPUNIT_ASSERT(testConversion(Interval::PI, 4));
+	CPPUNIT_ASSERT(testConversion(Interval::ONE, 3));
+	CPPUNIT_ASSERT(testConversion(Interval::POS_REALS, 3));
+	CPPUNIT_ASSERT(testConversion(Interval::NEG_REALS, 3));
 }
 
 } // end namespace

--- a/tests/TestString.h
+++ b/tests/TestString.h
@@ -5,8 +5,9 @@
  * License     : This program can be distributed under the terms of the GNU LGPL.
  *               See the file COPYING.LESSER.
  *
- * Author(s)   : Gilles Chabert
+ * Author(s)   : Gilles Chabert, Simon Rohou
  * Created     : Mar 2, 2012
+ * Updated     : April 18, 2016
  * ---------------------------------------------------------------------------- */
 
 #ifndef __TEST_STRING_H__
@@ -25,13 +26,15 @@ public:
 
 	CPPUNIT_TEST_SUITE(TestString);
 	
-
 		CPPUNIT_TEST(test01);
 		CPPUNIT_TEST(test02);
+		CPPUNIT_TEST(test03);
+		
 	CPPUNIT_TEST_SUITE_END();
 
 	void test01();
 	void test02();
+	void test03();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestString);


### PR DESCRIPTION
Add a function to convert an Interval object to a C string (char*) and its reciprocal feature:
* const char* intv2str(const Interval& intv, int precision)
* const Interval str2intv(const char* str)

This comes with unit tests.
Will be used for robotics purposes but should be implemented inside ibex-lib.