### PR TITLE
Remove spurious cout in qinter.

### DIFF
--- a/src/combinatorial/ibex_QInter.cpp
+++ b/src/combinatorial/ibex_QInter.cpp
@@ -70,9 +70,9 @@ IntervalVector qinter(const Array<IntervalVector>& _boxes, int q) {
 			size[i]=1;
 		}
 
-		cout << "i=" << i << endl;
-		for (int j=0; j<=size[i]; j++) cout << x[i][j] << " ";
-		cout << endl << endl;
+		// cout << "i=" << i << endl;
+		// for (int j=0; j<=size[i]; j++) cout << x[i][j] << " ";
+		// cout << endl << endl;
 
 	}
 


### PR DESCRIPTION
Commented out 3 lines of debug console output code in the qinter function (ibex_QInter.cpp)