### PR TITLE
[param-estim] Plugin compilation fix + Prevent cliquer.h inclusion in ibex.h

### DIFF
--- a/plugins/param-estim/src/ibex_KCoreGraph.cpp
+++ b/plugins/param-estim/src/ibex_KCoreGraph.cpp
@@ -1,4 +1,5 @@
 #include "ibex_KCoreGraph.h"
+#include "cliquer/graph.h"
 
 using namespace std;
 

--- a/plugins/param-estim/src/ibex_KCoreGraph.h
+++ b/plugins/param-estim/src/ibex_KCoreGraph.h
@@ -3,7 +3,6 @@
 
 #include "ibex_IntStack.h"
 #include "ibex_BitSet.h"
-#include "cliquer.h"
 
 #include <list>
 #include <vector>
@@ -15,6 +14,19 @@
  * Can be used like an IntStack of vertices. The edges must be added independently. 
  * 
  */
+ 
+// Forward declaration of graph_t type (quick and (very) dirty workaround to prevent 
+// "cliquer.h" inclusion).
+// \FIXME: the graph_t type should not be exposed like this in the interface, since it is
+//         polluting the global namespace (it comes from the cliquer library which is C).
+//         It is used as the return type of the "subgraph" member function.
+//        - if there is no use (neither internally nor externally) for the "subgraph" 
+//          function, just drop it from the interface;
+//        - if there is only internal use for the "subgraph" function, reimplement things 
+//          in order not to expose the graph_t type;
+//        - if there is external use for the "subgraph" function, an ibex-scoped graph 
+//          type has to be used
+typedef struct _graph_t graph_t;
 
 namespace ibex {
 

--- a/plugins/param-estim/wscript
+++ b/plugins/param-estim/wscript
@@ -31,4 +31,4 @@ def build (bld):
 	# add CLIQUER sources (excluding the "cl" application)
 	bld.env.IBEX_SRC.extend(bld.path.ant_glob ("src/cliquer/*.cpp", excl="**/cl.cpp"))
 	# add PARAM_ESTIM plugin headers
-	bld.env.IBEX_HDR.extend(bld.path.ant_glob ("src/**/*.h"))
+	bld.env.IBEX_HDR.extend(bld.path.ant_glob ("src/**/ibex_*.h"))

--- a/plugins/param-estim/wscript
+++ b/plugins/param-estim/wscript
@@ -28,7 +28,7 @@ def build (bld):
 
 	# add PARAM_ESTIM plugin sources
 	bld.env.IBEX_SRC.extend(bld.path.ant_glob ("src/**/ibex_*.cpp"))
+	# add CLIQUER sources (excluding the "cl" application)
+	bld.env.IBEX_SRC.extend(bld.path.ant_glob ("src/cliquer/*.cpp", excl="**/cl.cpp"))
 	# add PARAM_ESTIM plugin headers
 	bld.env.IBEX_HDR.extend(bld.path.ant_glob ("src/**/*.h"))
-	
-	


### PR DESCRIPTION
- Added cliquer .cpp source files to the build system, so that ibex_QInterEx_Cliquer can be properly built.

- Removed the `include "cliquer.h"` from ibex_KCoreGraph.h
- Removed the cliquer include files from Ibex installed include files

These two last changes are motivated since cliquer is C language code (put in .cpp files). It is not encapsulated in a namespace (this should be an easy fix). Also having cliquer .h files included in ibex.h creates a lot defines (hopefully written in full uppercase, but not prefixed), and also pollutes the global namespace.