### PR TITLE
[affine] wscript: don't try to build LinearRelaxAffine2 without --with-optim

### DIFF
--- a/plugins/affine/wscript
+++ b/plugins/affine/wscript
@@ -15,6 +15,9 @@ def configure (conf):
 	
 	Logs.pprint ("BLUE", "Configure the Affine Arithmetic plugin")
 	
+	if not conf.options.WITH_OPTIM:
+		Logs.pprint ("YELLOW", "Warning: The LinearRelaxAffine class (part of option --with-affine) will not be generated (requires --with-optim).")
+
 	# add AFFINE plugin include directory
 	conf.env.append_unique("INCLUDES","../../plugins/affine/src/arithmetic")
 	conf.env.append_unique("INCLUDES","../../plugins/affine/src/function")
@@ -27,10 +30,15 @@ def build (bld):
 	
 	Logs.pprint ("BLUE", "Build the Affine Arithmetic plugin")
 
+	excluded_files = None
+	# LinearRelaxAffine requires the LinearRelax base class from the optim plugin.
+	if not bld.env.WITH_OPTIM:
+		excluded_files = "src/numeric/ibex_LinearRelaxAffine2.*"
+
 	# add AFFINE plugin sources
-	bld.env.IBEX_SRC.extend(bld.path.ant_glob ("src/**/ibex_*.cpp"))
+	bld.env.IBEX_SRC.extend(bld.path.ant_glob ("src/**/ibex_*.cpp", excl=excluded_files))
 	# add AFFINE plugin headers
-	bld.env.IBEX_HDR.extend(bld.path.ant_glob ("src/**/ibex_*.h"))
+	bld.env.IBEX_HDR.extend(bld.path.ant_glob ("src/**/ibex_*.h", excl=excluded_files))
 	
 	# Add information in ibex_Setting
 	bld.env.settings['_IBEX_WITH_AFFINE_']='1'


### PR DESCRIPTION
The LinearRelaxAffine2 class from the affine plugin depends on the optim plugin.
This patch disables the generation of LinearRelaxAffine2 in case the `--with-affine` option is passed without the `--with-optim` option. A warning is displayed when running `./waf configure`