### PR TITLE
fix(function/ibex_Function.cpp): when Jacobian is empty, set its Hansen matrix to be empty

### DIFF
--- a/src/function/ibex_Function.cpp
+++ b/src/function/ibex_Function.cpp
@@ -109,6 +109,10 @@ void Function::hansen_matrix(const IntervalVector& box, IntervalMatrix& H) const
 		//var=tab[i];
 		x[var]=box[var];
 		jacobian(x,J);
+                if (J.is_empty()) {
+                    H.set_empty();
+                    return;
+                }
 		H.set_col(var,J.col(var));
 	}
 
@@ -132,6 +136,10 @@ void Function::hansen_matrix(const IntervalVector& box, IntervalMatrix& H, const
 		//var=tab[i];
 		x[var]=var_box[var];
 		jacobian(set.full_box(x,param_box),J,set);
+                if (J.is_empty()) {
+                    H.set_empty();
+                    return;
+                }
 		H.set_col(var,J.col(var));
 	}
 }


### PR DESCRIPTION
Related issue: https://github.com/ibex-team/ibex-lib/issues/198