### PR TITLE
[hotfix-163] add nb_var field in separator

### DIFF
--- a/src/set/ibex_Sep.cpp
+++ b/src/set/ibex_Sep.cpp
@@ -14,9 +14,6 @@ using namespace std;
 
 namespace ibex {
 
-Sep::Sep() : _status1(YES), _status2(NO) {
-}
-
 void Sep::contract(Set& set, double eps) {
 	set.root = set.root->inter(false, set.Rn, *this, eps);
 }

--- a/src/set/ibex_Sep.h
+++ b/src/set/ibex_Sep.h
@@ -55,20 +55,22 @@ namespace ibex {
 class Sep {
 
 public:
-
-	Sep();
-
 	/**
-     * \brief Separate a box in two sub-boxes.
-     *
-     * \param x_in  - As input: the initial box. As output:
-     *                result of the first ("inner") contraction
-     * \param x_out - As input: the initial box. As output:
-     *                the result of the second ("outer") contraction
-     *
-     * Precondition: x_in and x_out must be the same boxes.
+	 * \brief Build a separatot for n-dimensional boxes
 	 */
-    virtual void separate(IntervalVector& x_in, IntervalVector& x_out) = 0;
+	Sep(int nb_var);
+
+  /**
+   * \brief Separate a box in two sub-boxes.
+   *
+   * \param x_in  - As input: the initial box. As output:
+   *                result of the first ("inner") contraction
+   * \param x_out - As input: the initial box. As output:
+   *                the result of the second ("outer") contraction
+   *
+   * Precondition: x_in and x_out must be the same boxes.
+	 */
+  virtual void separate(IntervalVector& x_in, IntervalVector& x_out) = 0;
 
 	/**
 	 * \brief Contract a set with this separator.
@@ -103,15 +105,20 @@ public:
 	/**
 	 * \brief Delete *this.
 	 */
-    virtual ~Sep();
+  virtual ~Sep();
 
-    // Get current status of the 1st contraction
-    // (Used by SetBisect & SetLeaf)
-    BoolInterval status1() const;
+   /**
+	 * \brief The number of variables this contractor works with.
+	 */
+	const int nb_var;
 
-    // Get current status of the 2nd contraction
-    // (Used by SetBisect & SetLeaf)
-    BoolInterval status2() const;
+  // Get current status of the 1st contraction
+  // (Used by SetBisect & SetLeaf)
+  BoolInterval status1() const;
+
+  // Get current status of the 2nd contraction
+  // (Used by SetBisect & SetLeaf)
+  BoolInterval status2() const;
 
 private:
 
@@ -122,6 +129,8 @@ private:
 /* ============================================================================
  	 	 	 	 	 	 	 inline implementation
   ============================================================================*/
+
+inline Sep::Sep(int n) : nb_var(n), _status1(YES), _status2(NO) { }
 
 inline Sep::~Sep() { }
 

--- a/src/set/ibex_SepBoundaryCtc.cpp
+++ b/src/set/ibex_SepBoundaryCtc.cpp
@@ -1,5 +1,5 @@
 //============================================================================
-//                                  I B E X                                   
+//                                  I B E X
 // File        : ibex_SepBoundaryCtc.h
 // Author      : Gilles Chabert, Benoit Desrochers
 // Copyright   : Ecole des Mines de Nantes (France)
@@ -14,7 +14,7 @@ namespace ibex {
 
 const int SepBoundaryCtc::NB_SAMPLES = 1;
 
-SepBoundaryCtc::SepBoundaryCtc(Ctc& _ctc_boundary, Pdc& _is_inside) : ctc_boundary(_ctc_boundary), is_inside(_is_inside) {
+SepBoundaryCtc::SepBoundaryCtc(Ctc& _ctc_boundary, Pdc& _is_inside) : Sep(_is_inside.nb_var), ctc_boundary(_ctc_boundary), is_inside(_is_inside) {
 
 }
 

--- a/src/set/ibex_SepCtcPair.cpp
+++ b/src/set/ibex_SepCtcPair.cpp
@@ -1,5 +1,5 @@
 //============================================================================
-//                                  I B E X                                   
+//                                  I B E X
 // File        : ibex_SepCtcPair.cpp
 // Author      : Gilles Chabert
 // Copyright   : Ecole des Mines de Nantes (France)
@@ -12,7 +12,7 @@
 
 namespace ibex {
 
-SepCtcPair::SepCtcPair(Ctc& _ctc_in, Ctc& _ctc_out) : ctc_in(_ctc_in), ctc_out(_ctc_out) {
+SepCtcPair::SepCtcPair(Ctc& _ctc_in, Ctc& _ctc_out) : Sep(_ctc_in.nb_var), ctc_in(_ctc_in), ctc_out(_ctc_out) {
 
 }
 

--- a/src/set/ibex_SepInter.cpp
+++ b/src/set/ibex_SepInter.cpp
@@ -1,5 +1,5 @@
 //============================================================================
-//                                  I B E X                                   
+//                                  I B E X
 // File        : Intersection of separators
 // Author      : Benoit Desrochers
 // Copyright   : ENSTA Bretagne (France)
@@ -13,18 +13,18 @@
 
 namespace ibex {
 
-SepInter::SepInter(const Array<Sep>& list) : Sep(), list(list) {
+SepInter::SepInter(const Array<Sep>& list) : Sep(list[0].nb_var), list(list) {
 }
 
-SepInter::SepInter(Sep& s1, Sep& s2) : Sep(), list(Array<Sep>(s1,s2)) {
-
-}
-
-SepInter::SepInter(Sep& s1, Sep& s2, Sep& s3) : Sep(), list(Array<Sep>(s1,s2,s3)) {
+SepInter::SepInter(Sep& s1, Sep& s2) : Sep(s1.nb_var), list(Array<Sep>(s1,s2)) {
 
 }
 
-SepInter::SepInter(Sep &s1, Sep &s2, Sep &s3, Sep &s4) : Sep(), list(Array<Sep>(s1,s2,s3,s4))
+SepInter::SepInter(Sep& s1, Sep& s2, Sep& s3) : Sep(s1.nb_var), list(Array<Sep>(s1,s2,s3)) {
+
+}
+
+SepInter::SepInter(Sep &s1, Sep &s2, Sep &s3, Sep &s4) : Sep(s1.nb_var), list(Array<Sep>(s1,s2,s3,s4))
 {
 
 }

--- a/src/set/ibex_SepNot.cpp
+++ b/src/set/ibex_SepNot.cpp
@@ -1,5 +1,5 @@
 //============================================================================
-//                                  I B E X                                   
+//                                  I B E X
 // File        : ibex_SepNot.cpp
 // Author      : Gilles Chabert
 // Copyright   : Ecole des Mines de Nantes (France)
@@ -11,7 +11,7 @@
 
 namespace ibex {
 
-SepNot::SepNot(Sep& sep) : sep(sep) {
+SepNot::SepNot(Sep& sep) : Sep(sep.nb_var), sep(sep) {
 
 }
 

--- a/src/set/ibex_SepUnion.cpp
+++ b/src/set/ibex_SepUnion.cpp
@@ -1,5 +1,5 @@
 //============================================================================
-//                                  I B E X                                   
+//                                  I B E X
 // File        : ibex_SepUnion.cpp
 // Author      : Benoit Desrochers
 // Copyright   : Ecole des Mines de Nantes (France)
@@ -13,15 +13,15 @@
 
 namespace ibex {
 
-SepUnion::SepUnion(const Array<Sep>& list) : Sep(), list(list) {
+SepUnion::SepUnion(const Array<Sep>& list) : Sep(list[0].nb_var), list(list) {
 
 }
 
-SepUnion::SepUnion(Sep& s1, Sep& s2) : Sep(), list(Array<Sep>(s1,s2)) {
+SepUnion::SepUnion(Sep& s1, Sep& s2) : Sep(s1.nb_var), list(Array<Sep>(s1,s2)) {
 
 }
 
-SepUnion::SepUnion(Sep& s1, Sep& s2, Sep& s3) : Sep(), list(Array<Sep>(s1,s2,s3)) {
+SepUnion::SepUnion(Sep& s1, Sep& s2, Sep& s3) : Sep(s1.nb_var), list(Array<Sep>(s1,s2,s3)) {
 
 }
 

--- a/src/set/ibex_SepUnion.h
+++ b/src/set/ibex_SepUnion.h
@@ -1,5 +1,5 @@
 //============================================================================
-//                                  I B E X                                   
+//                                  I B E X
 // File        : Union of separators
 // Author      : Benoit Desrochers, Gilles Chabert
 // Copyright   : Ecole des Mines de Nantes (France)


### PR DESCRIPTION
Add nb_var argument to the separator class to be consistent with interface of Ctc and Pdc.