### PR TITLE
atan2(y,x) : parameters order confusion

### DIFF
--- a/newdoc/interval.rst
+++ b/newdoc/interval.rst
@@ -737,7 +737,7 @@ cos(x)       sin(x)   tan(x)
 acos(x)      asin(x)  atan(x)
 cosh(x)      sinh(x)  tanh(x)
 acosh(x)     asinh(x) atanh(x)
-atan2(x,y)
+atan2(y,x)
 ==========   ======== ========
 
 

--- a/plugins/affine/src/arithmetic/ibex_Affine.h
+++ b/plugins/affine/src/arithmetic/ibex_Affine.h
@@ -1046,10 +1046,10 @@ inline AffineMain<T> chi(const Interval&  a,const AffineMain<T>&  b,const Affine
 #endif /* IBEX_Affine_H_ */
 
 
-/** \brief atan2(AF[x],AF[y]). */
-//Affine2 atan2(const Affine2& x, const Affine2& y);
-/** \brief atan2([x],AF[y]). */
-//Affine2 atan2(const Interval& x, const Affine2& y);
-/** \brief atan2(AF[x],[y]). */
-//Affine2 atan2(const Affine2& x, const Interval& y);
+/** \brief atan2(AF[y],AF[x]). */
+//Affine2 atan2(const Affine2& y, const Affine2& x);
+/** \brief atan2([y],AF[x]). */
+//Affine2 atan2(const Interval& y, const Affine2& x);
+/** \brief atan2(AF[y],[x]). */
+//Affine2 atan2(const Affine2& y, const Interval& x);
 /** \brief cosh(AF[x]). */

--- a/src/arithmetic/ibex_Interval.h
+++ b/src/arithmetic/ibex_Interval.h
@@ -673,8 +673,8 @@ Interval asin(const Interval& x);
 /** \brief atan([x]). */
 Interval atan(const Interval& x);
 
-/** \brief atan2([x],[y]). */
-Interval atan2(const Interval& x, const Interval& y);
+/** \brief atan2([y],[x]). */
+Interval atan2(const Interval& y, const Interval& x);
 
 /** \brief cosh([x]). */
 Interval cosh(const Interval& x);

--- a/tests/TestExpr.cpp
+++ b/tests/TestExpr.cpp
@@ -290,7 +290,7 @@ void TestExpr::binaryOp() {
 	CPPUNIT_ASSERT(sameExpr(x/y,"(x/y)"));
 	CPPUNIT_ASSERT(sameExpr(max(x,y),"max(x,y)"));
 	CPPUNIT_ASSERT(sameExpr(min(x,y),"min(x,y)"));
-	CPPUNIT_ASSERT(sameExpr(atan2(x,y),"atan2(x,y)"));
+	CPPUNIT_ASSERT(sameExpr(atan2(y,x),"atan2(y,x)"));
 }
 
 void TestExpr::cst01() {


### PR DESCRIPTION
In some parts of the code, the parameters of atan2() are `y`, then `x` while the opposite can be found elsewhere.

For instance, in `ibex_Interval.h`:

``` C++
/** \brief atan2([x],[y]). */
Interval atan2(const Interval& x, const Interval& y);

...

inline Interval atan2(const Interval& y, const Interval& x) {

...
```

This can be dangerous.
I propose to update the function definition with the C++ atan2 convention. In the mean time, some updates are proposed in .rst files, the Affine part, the tests.