### PR TITLE
Enable builds using Python 3

### DIFF
--- a/waf_benchmarks.py
+++ b/waf_benchmarks.py
@@ -171,7 +171,7 @@ class BenchScatterPlotData (Bench):
 			for d in fdata:
 				uplo = max (uplo, d["uplo"])
 				loup = min (loup, d["loup"])
-			print uplo, loup
+			print (uplo, loup)
 			if uplo > loup:
 				err_fmt = "bench %s from %s: intersection of [uplo, loup] is empty"
 				err_data = (f, serie)

--- a/wscript
+++ b/wscript
@@ -28,7 +28,7 @@ def options (opt):
 	waflib.Tools.compiler_cxx.cxx_compiler["win32"].remove ("msvc")
 
 	opt.load ("compiler_cxx compiler_c javaw")
-	opt.load ("waf_benchmarks")
+	opt.load ("waf_benchmarks", tooldir='.')
 
 	opt.add_option ("--enable-shared", action="store_true", dest="ENABLE_SHARED",
 			help = "build ibex as a shared library")
@@ -246,12 +246,12 @@ def build (bld):
 
 	if bld.env.INSTALL_3RD:
 		incnode = bld.bldnode.find_node("3rd").find_node("include")
-		incfiles = incnode.ant_glob ("**")
+		incfiles = incnode.ant_glob ("**", quiet=True)
 		bld.install_files (bld.env.INCDIR_3RD, incfiles, cwd = incnode,
 			relative_trick = True)
 
 		libnode = bld.bldnode.find_node("3rd").find_node("lib")
-		libfiles = libnode.ant_glob ("**")
+		libfiles = libnode.ant_glob ("**", quiet=True)
 		bld.install_files (bld.env.LIBDIR_3RD, libfiles, cwd = libnode,
 			relative_trick = True)
 


### PR DESCRIPTION
Apply these changes to enable builds using Python 3. On certain systems, building with Python3 may require the latest Waf version (upcoming version 2.0.4 / master branch or waf-19 branch).