### PR TITLE
[src/doc]Set-visitor visit_node can stop set exploration

### DIFF
--- a/doc/set.rst
+++ b/doc/set.rst
@@ -133,8 +133,9 @@ Set Exploration
 The internal structure of sets is not intended to be handled directly by users (and may actually change with time).
 If you want to explore a set, you can use the ``SetVisitor`` class (following the
 `visitor design pattern`_) . This class must implement a ``visit_leaf``
-function that will be automatically called for every leaf of the set (it can also optionnaly implement a ``visit_node``
-function that is called for every intermediate node in the tree).
+function that will be automatically called for every leaf of the set. It can also optionnaly implement a ``visit_node``
+function that is called for every intermediate node in the tree, and tell wether or not to visit children of the current
+node by returning true (default) or false.
 
 .. _visitor design pattern : http://en.wikipedia.org/wiki/Visitor_pattern
 

--- a/src/set/ibex_SetBisect.cpp
+++ b/src/set/ibex_SetBisect.cpp
@@ -180,9 +180,10 @@ SetNode* SetBisect::contract_no_diff(BoolInterval status, const IntervalVector& 
 }
 
 void SetBisect::visit(const IntervalVector& nodebox, SetVisitor& visitor) const {
-	visitor.visit_node(nodebox);
-	left->visit(left_box(nodebox),visitor);
-	right->visit(right_box(nodebox),visitor);
+	if(visitor.visit_node(nodebox)){
+		left->visit(left_box(nodebox),visitor);
+		right->visit(right_box(nodebox),visitor);
+	}
 }
 
 void SetBisect::print(ostream& os, const IntervalVector& nodebox, int shift) const {

--- a/src/set/ibex_SetVisitor.h
+++ b/src/set/ibex_SetVisitor.h
@@ -28,7 +28,7 @@ public:
 	 *
 	 * By default, does nothing.
 	 */
-	virtual void visit_node(const IntervalVector&) { }
+	virtual bool visit_node(const IntervalVector&) { return true;}
 
 	/**
 	 * \brief Visit a leaf


### PR DESCRIPTION
Hello @gchabert , this simple modification of the set-visitor API allows for more efficient set exploration in cases where we do not need to manipulate every leaf of the set.

If you are OK with this change, I would like to update the set-visitor documentation before merging.