### PR TITLE
Use correct path to Clp header file in #include statement

### DIFF
--- a/plugins/lp_lib_clp/wscript
+++ b/plugins/lp_lib_clp/wscript
@@ -80,7 +80,7 @@ def configure (conf):
 
     conf.env.env = env_env_bak
 
-    conf.env.IBEX_LP_LIB_INCLUDES = '#include "coin/ClpSimplex.hpp"'
+    conf.env.IBEX_LP_LIB_INCLUDES = '#include "ClpSimplex.hpp"'
     conf.env.IBEX_LP_LIB_EXTRA_ATTRIBUTES = """
     ClpSimplex *myclp;
     int * _col1Index;


### PR DESCRIPTION
The Clp header files are meant to be referenced without the `coin/` prefix.

For instance, typically, `pkg-config --cflags clp` will return something like `-I/usr/include/coin` or `-I/home/martin/.local/include/coin`. So, if Clp is installed in a non-standard directory (e.g. on a cluster, or user-local install), the compiler won't be able to find `"coin/ClpSimplex.hpp"`, but it will always find `"ClpSimplex.hpp"` when pkg-config is used.

Also, the first code example in the official documentation, https://www.coin-or.org/Clp/userguide/ch02s02.html, uses `"ClpSimplex.hpp"`.

I have tested this both with and without `--clp-path`.