### PR TITLE
[fix] edge case with SepBoundary

### DIFF
--- a/src/set/ibex_SepBoundaryCtc.cpp
+++ b/src/set/ibex_SepBoundaryCtc.cpp
@@ -36,7 +36,7 @@ void SepBoundaryCtc::separate(IntervalVector& x_in, IntervalVector& x_out) {
 	x_in = box; x_out = box;
 
 	IntervalVector* rest;
-	int n=box0.diff(box,rest); // calculate the set difference
+	int n=box0.diff(box,rest, false); // calculate the set difference
 
 	BoolInterval res;
 
@@ -65,7 +65,12 @@ void SepBoundaryCtc::separate(IntervalVector& x_in, IntervalVector& x_out) {
 			}
 			else if (res==NO) {
 				x_in |= rest[i]; break;
+			} else {
+				x_in |=rest[i];
+				x_out |= rest[i];
+				break;
 			}
+
 			candidate_pt = rest[i].random();
 		}
 	}


### PR DESCRIPTION
Hi, 
This pull request aims at fixing these two issues with SepBoundary:
 - set compactness to false when computing the box difference.
 - handle the case when the predicate returns neither YES nor NO