### PR TITLE
[fix] msvc compilation error

### DIFF
--- a/src/set/ibex_SetNode.cpp
+++ b/src/set/ibex_SetNode.cpp
@@ -10,7 +10,6 @@
 #include "ibex_SetNode.h"
 #include "ibex_SetLeaf.h"
 #include "ibex_SetBisect.h"
- #include <unistd.h>
 
 using namespace std;
 

--- a/src/set/ibex_SetVisitor.h
+++ b/src/set/ibex_SetVisitor.h
@@ -1,5 +1,5 @@
 //============================================================================
-//                                  I B E X                                   
+//                                  I B E X
 // File        : ibex_SetVisitor.h
 // Author      : Gilles Chabert
 // Copyright   : Ecole des Mines de Nantes (France)
@@ -9,6 +9,8 @@
 
 #ifndef __IBEX_SET_VISITOR_H__
 #define __IBEX_SET_VISITOR_H__
+
+#include "ibex_BoolInterval.h"
 
 namespace ibex {
 

--- a/src/tools/ibex_String.cpp
+++ b/src/tools/ibex_String.cpp
@@ -1,5 +1,5 @@
 //============================================================================
-//                                  I B E X                                   
+//                                  I B E X
 // File        : ibex_String.cpp
 // Author      : Gilles Chabert
 // Copyright   : IMT Atlantique (France)
@@ -24,6 +24,7 @@ namespace ibex {
 
 #ifdef _MSC_VER
 #define SNPRINTF _snprintf
+#define __attribute__(x)
 #else
 #define SNPRINTF snprintf
 #endif // _MSC_VER

--- a/src/tools/ibex_mistral_Bitset.h
+++ b/src/tools/ibex_mistral_Bitset.h
@@ -15,6 +15,24 @@
 #include <string.h>
 
 
+#if defined(_MSC_VER)
+#include <intrin.h>
+
+static unsigned int __inline __builtin_ctz(unsigned int x){
+  unsigned long r = 0;
+  _BitScanForward(&r, x);
+  return r;
+}
+
+static unsigned int __inline __builtin_clz(unsigned int x){
+  unsigned long r = 0;
+  _BitScanReverse(&r, x);
+  return (32 - r);
+}
+#  define __builtin_popcount __popcnt
+#endif
+
+
 namespace Mistral {
 
 template <class WORD_TYPE>
@@ -1140,7 +1158,7 @@ typedef Bitset64 BitSet;
 typedef Bitset32 BitSet;
 
 #endif
-  
+
 } // end namespace Mistral
-  
+
 #endif

--- a/tests/TestArith.cpp
+++ b/tests/TestArith.cpp
@@ -13,6 +13,8 @@
 #include "ibex_Linear.h"
 #include "utils.h"
 #include <float.h>
+#define _USE_MATH_DEFINES
+#include <cmath>
 
 using namespace std;
 

--- a/tests/TestFunction.cpp
+++ b/tests/TestFunction.cpp
@@ -15,8 +15,17 @@
 #include "ibex_Expr.h"
 #include "ibex_SyntaxError.h"
 #include <sstream>
-#ifndef HAVE_FMEMOPEN
-  #include "fmemopen.h"
+#include <cstdio>
+
+// fmemopen doesn't exist on no POSIX system
+// The function is defined here
+#if defined(_MSC_VER) || defined(__clang__)
+inline FILE* fmemopen(void* data, int len, const char *mode ){
+       FILE * tempfile = tmpfile();
+       fwrite(data, len, 1, tempfile);
+       rewind(tempfile);
+       return tempfile;
+}
 #endif
 
 using namespace std;

--- a/tests/TestParser.cpp
+++ b/tests/TestParser.cpp
@@ -1,5 +1,5 @@
 //============================================================================
-//                                  I B E X                                   
+//                                  I B E X
 // File        : TestParser.cpp
 // Author      : Gilles Chabert
 // Copyright   : Ecole des Mines de Nantes (France)
@@ -15,9 +15,18 @@
 #include "ibex_SyntaxError.h"
 #include "ibex_CtcFwdBwd.h"
 #include "Ponts30.h"
-#ifndef HAVE_FMEMOPEN
-  #include "fmemopen.h"
+#include <cstdio>
+// fmemopen doesn't exist on no POSIX system
+// The function is defined here
+#if defined(_MSC_VER) || defined(__clang__)
+inline FILE* fmemopen(void* data, int len, const char *mode ){
+       FILE * tempfile = tmpfile();
+       fwrite(data, len, 1, tempfile);
+       rewind(tempfile);
+       return tempfile;
+}
 #endif
+
 
 using namespace std;
 
@@ -316,5 +325,3 @@ void TestParser::nary_max() {
 }
 
 } // end namespace
-
-


### PR DESCRIPTION
Set of small fixes to compile with mscv 
- add mising msvc function
- add missing preprocessor directive
- remove unused <unistd.h> header
- add fmemopen alternative