### PR TITLE
Add new sum function in Minibex

### DIFF
--- a/src/parser/ibex_P_Expr.cpp
+++ b/src/parser/ibex_P_Expr.cpp
@@ -80,14 +80,11 @@ P_ExprPower::P_ExprPower(const P_ExprNode& expr, const P_ExprNode& power) :
 }
 
 P_ExprSum::P_ExprSum(const P_ExprNode& expr, const char* iter, const P_ExprNode& first_value, const P_ExprNode& last_value) :
-		P_ExprNode(SUM), expr(expr), iter(strdup(iter)), first_value(first_value), last_value(last_value) {
+		P_ExprNode(SUM,first_value,last_value,expr), iter(strdup(iter)) {
 }
 
 P_ExprSum::~P_ExprSum() {
-	delete &expr;
 	free((char*) iter);
-	delete &first_value;
-	delete &last_value;
 }
 
 P_ExprIter::P_ExprIter(const char* name) : P_ExprNode(ITER), name(strdup(name)) {

--- a/src/parser/ibex_P_Expr.cpp
+++ b/src/parser/ibex_P_Expr.cpp
@@ -79,6 +79,17 @@ P_ExprPower::P_ExprPower(const P_ExprNode& expr, const P_ExprNode& power) :
 		P_ExprNode(POWER,expr,power) {
 }
 
+P_ExprSum::P_ExprSum(const P_ExprNode& expr, const char* iter, const P_ExprNode& first_value, const P_ExprNode& last_value) :
+		P_ExprNode(SUM), expr(expr), iter(strdup(iter)), first_value(first_value), last_value(last_value) {
+}
+
+P_ExprSum::~P_ExprSum() {
+	delete &expr;
+	free((char*) iter);
+	delete &first_value;
+	delete &last_value;
+}
+
 P_ExprIter::P_ExprIter(const char* name) : P_ExprNode(ITER), name(strdup(name)) {
 
 }

--- a/src/parser/ibex_P_Expr.h
+++ b/src/parser/ibex_P_Expr.h
@@ -169,10 +169,7 @@ public:
 
 	virtual void acceptVisitor(P_ExprVisitor& v) const { v.visit(*this); }
 
-	const P_ExprNode& expr;
 	const char* iter;
-	const P_ExprNode& first_value;
-	const P_ExprNode& last_value;
 };
 
 /*

--- a/src/parser/ibex_P_Expr.h
+++ b/src/parser/ibex_P_Expr.h
@@ -67,7 +67,7 @@ public:
 		IDX_ALL,       // all indices (:)
 		EXPR_WITH_IDX, // something(i1:i2,j1:j2)
 		ROW_VEC, COL_VEC, APPLY, CHI,
-		ADD, MUL, SUB, DIV, MAX, MIN, ATAN2, POWER,
+		ADD, MUL, SUB, DIV, MAX, MIN, ATAN2, POWER, SUM,
 		MINUS, TRANS, SIGN, ABS,
 		SQR, SQRT, EXP, LOG,
 		COS,  SIN,  TAN,  ACOS,  ASIN,  ATAN,
@@ -155,6 +155,24 @@ public:
 	P_ExprPower(const P_ExprNode& expr, const P_ExprNode& power);
 
 	virtual void acceptVisitor(P_ExprVisitor& v) const { v.visit(*this); }
+};
+
+/**
+ * \brief Sum expression.
+ *
+ */
+class P_ExprSum : public P_ExprNode {
+public:
+	P_ExprSum(const P_ExprNode& expr, const char* iter, const P_ExprNode& first_value, const P_ExprNode& last_value);
+
+	~P_ExprSum();
+
+	virtual void acceptVisitor(P_ExprVisitor& v) const { v.visit(*this); }
+
+	const P_ExprNode& expr;
+	const char* iter;
+	const P_ExprNode& first_value;
+	const P_ExprNode& last_value;
 };
 
 /*
@@ -365,6 +383,10 @@ inline const P_ExprNode* atan2(const P_ExprNode* left, const P_ExprNode* right) 
 
 inline const P_ExprNode* pow(const P_ExprNode* left, const P_ExprNode* right) {
 	return new P_ExprPower(*left,*right);
+}
+
+inline const P_ExprNode* sum(const P_ExprNode* expr, const char* iter, const P_ExprNode* first_value, const P_ExprNode* last_value) {
+	return new P_ExprSum(*expr , iter, *first_value, *last_value);
 }
 
 inline const P_ExprNode* chi(const P_ExprNode* exp1, const P_ExprNode* exp2, const P_ExprNode* exp3) {

--- a/src/parser/ibex_P_ExprGenerator.cpp
+++ b/src/parser/ibex_P_ExprGenerator.cpp
@@ -457,12 +457,17 @@ void ExprGenerator::visit(const P_ExprSum& e) {
 
 	int begin=first_value._2int();
 	int end=last_value._2int();
-
+	if(end < begin) {
+		ostringstream s;
+		s << "first value < end value (" << begin << " < " << end << "). ";
+		s << "First value must be >= end value.";
+		throw SyntaxError(s.str());
+	}
 	scope.add_iterator(name);
 	const ExprNode* node;
 
 	bool is_const = true;
-	Domain* domain;
+	Domain* domain = nullptr;
 	// Visit with begin value to initialize the node value
 	scope.set_iter_value(name,begin);
 	visit(expr);
@@ -487,9 +492,11 @@ void ExprGenerator::visit(const P_ExprSum& e) {
 
 	if(is_const) {
 		e.lab = new LabelConst(*domain);
+		cleanup(*node, false);
 	} else {
 		e.lab = new LabelNode(node);
 	}
+	delete domain;
 	scope.rem_iterator(name);
 }
 

--- a/src/parser/ibex_P_ExprGenerator.cpp
+++ b/src/parser/ibex_P_ExprGenerator.cpp
@@ -445,13 +445,18 @@ void ExprGenerator::visit(const P_ExprPower& e) {
 }
 
 void ExprGenerator::visit(const P_ExprSum& e) {
-	visit(e.first_value);
-	visit(e.last_value);
+
+	const P_ExprNode& first_value = e.arg[0];
+	const P_ExprNode& last_value  = e.arg[1];
+	const P_ExprNode& expr        = e.arg[2];
+
+	visit(first_value);
+	visit(last_value);
 
 	const char* name     = e.iter;
 
-	int begin=e.first_value._2int();
-	int end=e.last_value._2int();
+	int begin=first_value._2int();
+	int end=last_value._2int();
 
 	scope.add_iterator(name);
 	const ExprNode* node;
@@ -460,24 +465,24 @@ void ExprGenerator::visit(const P_ExprSum& e) {
 	Domain* domain;
 	// Visit with begin value to initialize the node value
 	scope.set_iter_value(name,begin);
-	visit(e.expr);
-	if(e.expr.lab->is_const()) {
-		domain = new Domain(e.expr.lab->domain());
+	visit(expr);
+	if(expr.lab->is_const()) {
+		domain = new Domain(expr.lab->domain());
 	} else {
 		is_const = false;
 	}
-	node = &e.expr.lab->node();
-	e.expr.cleanup();
+	node = &expr.lab->node();
+	expr.cleanup();
 	for (int i=begin+1; i<=end; i++) {
 		scope.set_iter_value(name,i);
-		visit(e.expr);
-		if(!e.expr.lab->is_const()) {
+		visit(expr);
+		if(!expr.lab->is_const()) {
 			is_const = false;
 		} else if(is_const) {
-			*domain = *domain + e.expr.lab->domain();
+			*domain = *domain + expr.lab->domain();
 		}
-		node =&(*node + e.expr.lab->node());
-		e.expr.cleanup();
+		node =&(*node + expr.lab->node());
+		expr.cleanup();
 	}
 
 	if(is_const) {

--- a/src/parser/ibex_P_ExprGenerator.cpp
+++ b/src/parser/ibex_P_ExprGenerator.cpp
@@ -469,7 +469,7 @@ void ExprGenerator::visit(const P_ExprSum& e) {
 	node = &e.expr.lab->node();
 	e.expr.cleanup();
 	for (int i=begin+1; i<=end; i++) {
-		scopes().top().set_iter_value(name,i);
+		scope.set_iter_value(name,i);
 		visit(e.expr);
 		if(!e.expr.lab->is_const()) {
 			is_const = false;

--- a/src/parser/ibex_P_ExprGenerator.h
+++ b/src/parser/ibex_P_ExprGenerator.h
@@ -44,13 +44,14 @@ protected:
 	// some nodes require more specific code:
 	void visit(const P_ExprWithIndex&);
 	void visit(const P_ExprPower&);
+	void visit(const P_ExprSum&);
 	const ExprNode& diff(const Array<const ExprNode>& args);
 
 	std::pair<int,int> visit_index_tmp(const Dim& dim, const P_ExprNode& idx, bool matlab_style);
 	DoubleIndex visit_index(const Dim& dim, const P_ExprNode& idx1, bool matlab_style);
 	DoubleIndex visit_index(const Dim& dim, const P_ExprNode& idx1, const P_ExprNode& idx2, bool matlab_style);
 
-	const Scope& scope;
+	Scope& scope;
 };
 
 #ifdef __clang__

--- a/src/parser/ibex_P_ExprPrinter.cpp
+++ b/src/parser/ibex_P_ExprPrinter.cpp
@@ -98,10 +98,10 @@ void P_ExprPrinter::visit(const P_ExprWithIndex& e) {
 
 void P_ExprPrinter::visit(const P_ExprSum& e) {
 	os << "sum(" << e.iter << "=";
-	visit(e.first_value);
-	visit(e.last_value);
+	visit(e.arg[0]);
+	visit(e.arg[1]);
 	os << ", ";
-	visit(e.expr);
+	visit(e.arg[2]);
 }
 
 } // end namespace parser

--- a/src/parser/ibex_P_ExprPrinter.cpp
+++ b/src/parser/ibex_P_ExprPrinter.cpp
@@ -53,6 +53,7 @@ void P_ExprPrinter::visit(const P_ExprNode& e) {
 	case P_ExprNode::MIN:			os << "min";   print_arg_list(e);  break;
 	case P_ExprNode::ATAN2:         os << "atan2"; print_arg_list(e);  break;
 	case P_ExprNode::POWER:         visit(e.arg[0]); os << "^"; visit(e.arg[1]); break;
+	case P_ExprNode::SUM:			e.acceptVisitor(*this); 		   break;
 	case P_ExprNode::MINUS:         os << "-" ; visit(e.arg[0]);       break;
 	case P_ExprNode::TRANS:         print_arg_list(e); os << "'";      break;
 	case P_ExprNode::SIGN:          os << "sign";  print_arg_list(e);  break;
@@ -93,6 +94,14 @@ void P_ExprPrinter::visit(const P_ExprWithIndex& e) {
 		visit(e.arg[2]);
 	}
 	os << (e.matlab_style? ')' : ']');
+}
+
+void P_ExprPrinter::visit(const P_ExprSum& e) {
+	os << "sum(" << e.iter << "=";
+	visit(e.first_value);
+	visit(e.last_value);
+	os << ", ";
+	visit(e.expr);
 }
 
 } // end namespace parser

--- a/src/parser/ibex_P_ExprPrinter.h
+++ b/src/parser/ibex_P_ExprPrinter.h
@@ -31,6 +31,7 @@ public:
 protected:
 	void visit(const P_ExprNode& e);
 	void visit(const P_ExprWithIndex&);
+	void visit(const P_ExprSum&);
 
 	void print_arg_list(const P_ExprNode&, bool);
 

--- a/src/parser/ibex_P_ExprVisitor.h
+++ b/src/parser/ibex_P_ExprVisitor.h
@@ -20,6 +20,7 @@ namespace parser {
 class P_ExprNode;
 class P_ExprWithIndex;
 class P_ExprPower;
+class P_ExprSum;
 class P_ExprVarSymbol;
 class P_ExprCstSymbol;
 class P_ExprConstant;
@@ -49,6 +50,11 @@ public:
 
 	/** Visit a parser power expression. */
 	virtual void visit(const P_ExprPower& e) {
+		visit((const P_ExprNode&) e);
+	}
+
+	/** Visit a parser sum expression. */
+	virtual void visit(const P_ExprSum& e) {
 		visit((const P_ExprNode&) e);
 	}
 

--- a/src/parser/ibex_Scope.cpp
+++ b/src/parser/ibex_Scope.cpp
@@ -209,6 +209,12 @@ void Scope::add_iterator(const char* id) {
 	tab.insert_new(id, new S_Iterator(-1));
 }
 
+void Scope::rem_iterator(const char* id) {
+	assert(tab[id]->token()==TK_ITERATOR);
+	delete tab[id];
+	tab.erase(id);
+}
+
 //std::pair<const ExprConstant*, const Domain*> Scope::get_cst(const char* id) const {
 const ExprConstant& Scope::get_cst(const char* id) const {
 	const S_Object& o=*tab[id];

--- a/src/parser/ibex_Scope.h
+++ b/src/parser/ibex_Scope.h
@@ -64,6 +64,10 @@ public:
 	/** Add an (uninitialized) iterator. */
 	void add_iterator(const char* id);
 
+	/** Remove an iterator
+	 */
+	void rem_iterator(const char* id);
+
 	//void add_operator(const char* id);
 
 	/*------------- get data associated to symbols in the current scope -----------*/

--- a/src/parser/lexer.l
+++ b/src/parser/lexer.l
@@ -88,6 +88,7 @@ using namespace ibex::parser;
 "inf"                            { return TK_INF; }
 "mid"                            { return TK_MID; }
 "sup"                            { return TK_SUP; }
+"sum"                            { return TK_SUM; }
 
 "return"|"Return"|"RETURN"       { return TK_RETURN; }
 "begin"|"Begin"|"BEGIN"          { return TK_BEGIN; }

--- a/src/parser/parser.yc
+++ b/src/parser/parser.yc
@@ -49,7 +49,7 @@
 
 %token TK_PARAM TK_CONST TK_VARS TK_FUNCTION 
 %token TK_DIFF 
-%token TK_MIN TK_MAX TK_INF TK_MID TK_SUP TK_SIGN TK_ABS
+%token TK_MIN TK_MAX TK_INF TK_MID TK_SUP TK_SIGN TK_ABS TK_SUM
 %token TK_SQRT TK_EXPO  TK_LOG 
 %token TK_COS  TK_SIN   TK_TAN  TK_ACOS  TK_ASIN  TK_ATAN TK_ATAN2
 %token TK_COSH TK_SINH  TK_TANH TK_ACOSH TK_ASINH TK_ATANH
@@ -261,6 +261,17 @@ expr          : expr '+' expr	                { $$ = *$1 + *$3;     }
               | expr '/' expr	                { $$ = *$1 / *$3;     }
               | TK_MAX '(' expr_row ')'         { $$ = max($3);       }
               | TK_MIN '(' expr_row ')'         { $$ = min($3);       }
+              | TK_SUM '(' TK_NEW_SYMBOL TK_EQU expr ':' expr ','
+                                              { 
+                                                scopes().push(scopes().top());
+                                                scopes().top().add_iterator($3);
+                                              }
+                expr ')'  
+                                              {
+                                                $$ = sum($10, $3, $5, $7);
+                                                scopes().pop();
+                                                free($3);
+                                              }
               | TK_ATAN2 '(' expr ',' expr ')'  { $$ = atan2($3,$5);  }
               | '-' expr                        { $$ = -*$2;          }
               | TK_ABS  '(' expr ')'            { $$ = abs  ($3);     }

--- a/tests/TestParser.cpp
+++ b/tests/TestParser.cpp
@@ -334,7 +334,29 @@ void TestParser::sum01() {
 }
 
 void TestParser::sum02() {
+	CPPUNIT_ASSERT_THROW(Function("x","sum(x=1:4,0)"), SyntaxError);
 	CPPUNIT_ASSERT_THROW(Function("x[4]","sum(i=1:0,x(i))"), SyntaxError);
+	CPPUNIT_ASSERT_THROW(Function("x[4]","sum(i=1:2,sum(i=1:2,x(i)))"), SyntaxError);
 }
+
+void TestParser::sum03() {
+	try {
+		Function f("x[4]","sum(i=1:4,i)");
+		CPPUNIT_ASSERT(dynamic_cast<const ExprConstant*>(&f.expr())!=NULL);
+		CPPUNIT_ASSERT(sameExpr(f.expr(),"10"));
+	} catch(SyntaxError&) {
+		CPPUNIT_ASSERT(false);
+	}
+}
+
+void TestParser::sum04() {
+	try {
+		Function f("x[4]","sum(i=1:2,sum(j=1:2,x(i+j)))");
+		CPPUNIT_ASSERT(sameExpr(f.expr(),"((x(2)+x(3))+(x(3)+x(4)))"));
+	} catch(SyntaxError&) {
+		CPPUNIT_ASSERT(false);
+	}
+}
+
 
 } // end namespace

--- a/tests/TestParser.cpp
+++ b/tests/TestParser.cpp
@@ -324,4 +324,17 @@ void TestParser::nary_max() {
 
 }
 
+void TestParser::sum01() {
+	try {
+		Function f("x[4]","sum(i=1:4,x(i))");
+		CPPUNIT_ASSERT(sameExpr(f.expr(),"(((x(1)+x(2))+x(3))+x(4))"));
+	} catch(SyntaxError&) {
+		CPPUNIT_ASSERT(false);
+	}
+}
+
+void TestParser::sum02() {
+	CPPUNIT_ASSERT_THROW(Function("x[4]","sum(i=1:0,x(i))"), SyntaxError);
+}
+
 } // end namespace

--- a/tests/TestParser.h
+++ b/tests/TestParser.h
@@ -43,6 +43,8 @@ public:
 	CPPUNIT_TEST(issue245_2);
 	CPPUNIT_TEST(issue245_3);
 	CPPUNIT_TEST(nary_max);
+	CPPUNIT_TEST(sum01);
+	//CPPUNIT_TEST(sum02);
 	//		CPPUNIT_TEST(error01);
 	CPPUNIT_TEST_SUITE_END();
 
@@ -63,6 +65,9 @@ public:
 	void issue245_2();
 	void issue245_3();
 	void nary_max();
+
+	void sum01();
+	void sum02();
 
 };
 

--- a/tests/TestParser.h
+++ b/tests/TestParser.h
@@ -44,7 +44,9 @@ public:
 	CPPUNIT_TEST(issue245_3);
 	CPPUNIT_TEST(nary_max);
 	CPPUNIT_TEST(sum01);
-	//CPPUNIT_TEST(sum02);
+	CPPUNIT_TEST(sum02);
+	CPPUNIT_TEST(sum03);
+	CPPUNIT_TEST(sum04);
 	//		CPPUNIT_TEST(error01);
 	CPPUNIT_TEST_SUITE_END();
 
@@ -68,7 +70,8 @@ public:
 
 	void sum01();
 	void sum02();
-
+	void sum03();
+	void sum04();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestParser);


### PR DESCRIPTION
Hello,

Je propose un nouvel opérateur pour faire facilement des sommes en Minibex.

A voir pour changer la syntaxe, pour l'instant c'est du style
```
sum(nom_iter=expr_debut:expr_fin, expr)
```

J'ai dû modifier `const Scope& scope` en `Scope& scope` dans `ExprGenerator`, pour pouvoir ajouter l'itérateur uniquement au scope de l'opérateur sum.

On vérifie aussi si le résultat de la somme est constant :).

Tell me what you think, c'est une proposition.