### PR TITLE
Add support for coinutils being located outside the clp install tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required (VERSION 3.0.2)
 
 message (WARNING "CMake support is still experimental, use waf to build Ibex")
 
-project (IBEX VERSION 2.8.0 LANGUAGES CXX)
+project (IBEX VERSION 2.8.6 LANGUAGES CXX)
 set (IBEX_DESCRIPTION "A C++ library for interval-based algorithm design")
 set (IBEX_URL "http://www.ibex-lib.org/")
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -223,6 +223,12 @@ In particular, ``waf`` ``configure`` supports the following options:
                         If Ibex is compiled as a shared library, you must also add the libpath of CLP in ``LD_LIBRARY_PATH``.
                         
 
+--coinutils-path=PATH   Set the (absolute) path of CoinUtils to PATH (to be used with ``--lp-lib=clp`` and ``--clp-path``). The plugin archive contains 
+                        a version of CLP that includes CoinUtils so this option is not required.
+                        PATH is the absolute path where CoinUtils is installed (don’t use relative path like ``--coinutils-path=../coinutils-xx``).       
+                        If Ibex is compiled as a shared library, you must also add the libpath of CoinUtils in ``LD_LIBRARY_PATH``.
+
+
 --lp-lib=cplex          Install Ibex with the LP Solver CPLEX. The path of CPLEX must be provided with the ``--cplex-path`` option.
                         This option is **experimental**, i.e., support for installation issues may not be guaranteed. 
 

--- a/lp_lib_wrapper/clp/wscript
+++ b/lp_lib_wrapper/clp/wscript
@@ -13,6 +13,11 @@ def options (opt):
                     default = "",
                     help = "location of the Clp lib and include directories \
                             (by default use the one in 3rd directory)")
+    grp.add_option ("--coinutils-path", action="store", type="string",
+                    dest="COINUTILS_PATH", default = "",
+                    help = "location of the CoinUtils lib and include directories \
+                            (by default use the location of the Clp lib and \
+                            include directories)")
 
 ######################
 ##### configure ######
@@ -23,14 +28,26 @@ def configure (conf):
     conf.env["LP_LIB"] = "CLP"
 
     clp_dir = conf.options.CLP_PATH
+    coinutils_dir = conf.options.COINUTILS_PATH
     if clp_dir:
+        if not coinutils_dir:
+            coinutils_dir = clp_dir
         clp_include = os.path.join (clp_dir, "include")
-        # Cpl install everything in coin directory
-        coin_include = os.path.join (clp_include, "coin")
+        clp_include_clp = os.path.join (clp_include, "clp")
+        if os.path.exists (clp_include_clp):
+            clp_include = clp_include_clp
+        clp_include = os.path.join (clp_include, "coin")
+        coinutils_include = os.path.join (coinutils_dir, "include")
+        coinutils_include_coin = os.path.join (coinutils_include, "coinutils")
+        if os.path.exists (coinutils_include_coin):
+            coinutils_include = coinutils_include_coin
+        coinutils_include = os.path.join (coinutils_include, "coin")
         clp_lib = os.path.join (clp_dir, "lib")
+        coinutils_lib = os.path.join (coinutils_dir, "lib")
         conf.env.append_unique ("INCLUDES_IBEX_DEPS", clp_include)
-        conf.env.append_unique ("INCLUDES_IBEX_DEPS", coin_include)
+        conf.env.append_unique ("INCLUDES_IBEX_DEPS", coinutils_include)
         conf.env.append_unique ("LIBPATH_IBEX_DEPS", clp_lib)
+        conf.env.append_unique ("LIBPATH_IBEX_DEPS", coinutils_lib)
     else:
         clp_include = ""
         clp_lib = ""
@@ -55,10 +72,10 @@ def configure (conf):
             if clp_lib:
                 ## add to the environnement the path where clp.pc should be
                 clp_pc_install_path = os.path.join (clp_lib, "pkgconfig")
+                coinutils_pc_install_path = os.path.join (coinutils_lib, "pkgconfig")
                 if conf.env.env == []:
                     conf.env.env = {}
-                conf.env.env["PKG_CONFIG_PATH"] = clp_pc_install_path
-    
+                conf.env.env["PKG_CONFIG_PATH"] = ":".join ([clp_pc_install_path, coinutils_pc_install_path])
             clp_kwargs["mandatory"] = mandatory
             has_clp = conf.check_cfg (**clp_kwargs)
     

--- a/wscript
+++ b/wscript
@@ -7,7 +7,7 @@ from waflib import Scripting, Logs, Options, Utils
 import ibexutils
 
 # The following variable is used to build ibex.pc and by "waf dist"
-VERSION="2.8.3"
+VERSION="2.8.6"
 # The following variable is used only by "waf dist"
 APPNAME='ibex-lib'
 


### PR DESCRIPTION
This is mostly to enable the use of [`clp`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/clp.rb) and [`coinutils`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/coinutils.rb) from Homebrew, including potentially in the [`ibex`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/ibex) formula. Typically headers are located in `/usr/local/opt/clp/include/clp/coin` and `/usr/local/opt/coinutils/include/coinutils/coin` and libraries in `/usr/local/opt/clp/lib` and `/usr/local/opt/coinutils/lib`, a configuration not supported by the current `waf` scripts.

Note also the version numbers were not incremented in the last few releases, so I have fixed that and it might be a good idea to cut a 2.8.6 release so that consumers (including Homebrew) have the correct `ibex.pc` file if/when this PR is merged.