### PR TITLE
Add initializer_list constructors to basic types

### DIFF
--- a/src/arithmetic/ibex_Interval.h
+++ b/src/arithmetic/ibex_Interval.h
@@ -891,13 +891,9 @@ inline Interval::Interval(double a) : itv(a,a) {
 	if (a==NEG_INFINITY || a==POS_INFINITY) *this=EMPTY_SET;
 }
 
-inline Interval::Interval(std::array<double, 1> array): itv(array[0], array[0]) {
-    if (array[0]==NEG_INFINITY || array[0]==POS_INFINITY) *this=EMPTY_SET;
-}
+inline Interval::Interval(std::array<double, 1> array): Interval(array[0]) {}
 
-inline Interval::Interval(std::array<double, 2> array): itv(array[0], array[1]) {
-    if (array[0]==POS_INFINITY || array[1]==NEG_INFINITY || array[0]>array[1]) *this=EMPTY_SET;
-}
+inline Interval::Interval(std::array<double, 2> array): Interval(array[0], array[1]) {}
 
 inline bool Interval::operator==(const Interval& x) const {
 	return (is_empty() && x.is_empty()) || (lb()==x.lb() && ub()==x.ub());

--- a/src/arithmetic/ibex_Interval.h
+++ b/src/arithmetic/ibex_Interval.h
@@ -14,6 +14,7 @@
 #ifndef _IBEX_INTERVAL_H_
 #define _IBEX_INTERVAL_H_
 
+#include <array>
 #include <math.h>
 #include "ibex_Exception.h"
 
@@ -109,6 +110,12 @@ class Interval {
 
     /** \brief Create [a,a]. */
     Interval(double a);
+
+    /** \brief Create [a, a] from a fixed-sized array of size 1. */
+    Interval(std::array<double, 1> array);
+
+    /** \brief Create [a, b] from a fixed-sized array of size 2. */
+    Interval(std::array<double, 2> array);
 
     /** \brief True iff *this and x are exactly the same intervals. */
     bool operator==(const Interval& x) const;
@@ -439,71 +446,71 @@ class Interval {
      *  Deprecated. Use pi().
      */
     static const Interval PI;
-    
+
      /** \brief pi. */
     static const Interval& pi();
-    
+
     /** \brief 2*pi.
      *  Deprecated. Use two_pi().
      */
     static const Interval TWO_PI;
- 
+
     /** \brief 2*pi. */
     static const Interval& two_pi();
-    
+
     /** \brief pi/2.
      *  Deprecated. Use half_pi().
      */
     static const Interval HALF_PI;
-    
+
     /** \brief pi/2. */
     static const Interval& half_pi();
-    
-    /** \brief the empty interval. 
+
+    /** \brief the empty interval.
      *  Deprecated. Use empty_set().
      */
     static const Interval EMPTY_SET;
-    
+
     /** \brief the empty interval. */
     static const Interval& empty_set();
-    
-    /** \brief (-oo,oo). 
+
+    /** \brief (-oo,oo).
      *  Deprecated. Use all_reals().
      */
     static const Interval ALL_REALS;
-    
+
     /** \brief (-oo,oo). */
     static const Interval& all_reals();
-    
-    /** \brief [0,0]. 
+
+    /** \brief [0,0].
      *  Deprecated. Use zero().
      */
     static const Interval ZERO;
-    
+
     /** \brief [0,0]. */
     static const Interval& zero();
-    
-    /** \brief [1,1]. 
+
+    /** \brief [1,1].
      *  Deprecated. Use one().
      */
     static const Interval ONE;
-    
+
     /** \brief [1,1]. */
     static const Interval& one();
-    
-    /** \brief [0,+oo). 
+
+    /** \brief [0,+oo).
      *  Deprecated. Use pos_reals().
      */
     static const Interval POS_REALS;
-    
+
     /** \brief [0,+oo). */
     static const Interval& pos_reals();
-    
-    /** \brief (-oo,0]. 
+
+    /** \brief (-oo,0].
      *  Deprecated. Use neg_reals().
      */
     static const Interval NEG_REALS;
-    
+
     /** \brief (-oo,0]. */
     static const Interval& neg_reals();
 
@@ -882,6 +889,14 @@ inline Interval::Interval(double a, double b) : itv(a,b) {
 
 inline Interval::Interval(double a) : itv(a,a) {
 	if (a==NEG_INFINITY || a==POS_INFINITY) *this=EMPTY_SET;
+}
+
+inline Interval::Interval(std::array<double, 1> array): itv(array[0], array[0]) {
+    if (array[0]==NEG_INFINITY || array[0]==POS_INFINITY) *this=EMPTY_SET;
+}
+
+inline Interval::Interval(std::array<double, 2> array): itv(array[0], array[1]) {
+    if (array[0]==POS_INFINITY || array[1]==NEG_INFINITY || array[0]>array[1]) *this=EMPTY_SET;
 }
 
 inline bool Interval::operator==(const Interval& x) const {

--- a/src/arithmetic/ibex_IntervalMatrix.cpp
+++ b/src/arithmetic/ibex_IntervalMatrix.cpp
@@ -55,6 +55,17 @@ IntervalMatrix::IntervalMatrix(int m, int n, double bounds[][2]) : _nb_rows(m), 
 	}
 }
 
+IntervalMatrix::IntervalMatrix(std::initializer_list<IntervalVector> list): _nb_rows(list.size()) {
+	assert(_nb_rows > 0);
+	M = new IntervalVector[_nb_rows];
+	_nb_cols = list.begin()->size();
+	int i = 0;
+	for(const IntervalVector& v : list) {
+		assert(v == _nb_cols);
+		M[i++] = v;
+	}
+}
+
 IntervalMatrix::IntervalMatrix(const IntervalMatrix& m) : _nb_rows(m.nb_rows()), _nb_cols(m.nb_cols()){
 	M = new IntervalVector[_nb_rows];
 	for (int i=0; i<_nb_rows; i++) {

--- a/src/arithmetic/ibex_IntervalMatrix.cpp
+++ b/src/arithmetic/ibex_IntervalMatrix.cpp
@@ -61,7 +61,7 @@ IntervalMatrix::IntervalMatrix(std::initializer_list<IntervalVector> list): _nb_
 	_nb_cols = list.begin()->size();
 	int i = 0;
 	for(const IntervalVector& v : list) {
-		assert(v == _nb_cols);
+		assert(v.size() == _nb_cols);
 		M[i++] = v;
 	}
 }

--- a/src/arithmetic/ibex_IntervalMatrix.h
+++ b/src/arithmetic/ibex_IntervalMatrix.h
@@ -15,6 +15,7 @@
 #include "ibex_IntervalVector.h"
 #include "ibex_Matrix.h"
 
+#include <initializer_list>
 #include <iostream>
 
 namespace ibex {
@@ -62,6 +63,12 @@ public:
 	 */
 	IntervalMatrix(int m, int n, double x[][2]);
 
+	/**
+	 * Create a matrix from a list of Vector.
+	 *
+	 * \pre list.size() > 0, all Vectors of list must be of the same size.
+	 */
+	IntervalMatrix(std::initializer_list<IntervalVector> list);
 	/**
 	 * \brief Delete *this.
 	 */

--- a/src/arithmetic/ibex_IntervalVector.cpp
+++ b/src/arithmetic/ibex_IntervalVector.cpp
@@ -46,6 +46,11 @@ IntervalVector::IntervalVector(int n1, double bounds[][2]) : n(n1), vec(new Inte
 			vec[i]=Interval(bounds[i][0],bounds[i][1]);
 }
 
+IntervalVector::IntervalVector(std::initializer_list<Interval> list) : n(list.size()), vec(new Interval[n]) {
+	assert(n >= 1);
+	std::copy(list.begin(), list.end(), vec);
+}
+
 IntervalVector::IntervalVector(const Vector& x) : n(x.size()), vec(new Interval[n]) {
 	for (int i=0; i<n; i++) vec[i]=x[i];
 }

--- a/src/arithmetic/ibex_IntervalVector.h
+++ b/src/arithmetic/ibex_IntervalVector.h
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <iostream>
 #include <utility>
+#include <initializer_list>
 #include "ibex_Interval.h"
 #include "ibex_InvalidIntervalVectorOp.h"
 #include "ibex_Vector.h"
@@ -88,6 +89,14 @@ public:
 	 * \pre n>0
 	 */
 	IntervalVector(int n, double  bounds[][2]);
+
+	/**
+	 * \brief Create the IntervalVector from a list of Interval.
+	 *
+	 * \param list a list of Interval
+	 * \pre list not empty
+	 */
+	IntervalVector(std::initializer_list<Interval> list);
 
 	/**
 	 * \brief Create the degenerated IntervalVector x

--- a/src/arithmetic/ibex_Matrix.cpp
+++ b/src/arithmetic/ibex_Matrix.cpp
@@ -56,6 +56,17 @@ Matrix::Matrix(int m, int n, double x[]) : _nb_rows(m), _nb_cols(n) {
 	}
 }
 
+Matrix::Matrix(std::initializer_list<Vector> list): _nb_rows(list.size()) {
+	assert(_nb_rows > 0);
+	M = new Vector[_nb_rows];
+	_nb_cols = list.begin()->size();
+	int i = 0;
+	for(const Vector& v : list) {
+		assert(v.size() == _nb_cols);
+		M[i++] = v;
+	}
+}
+
 Matrix::Matrix(const Matrix& m) : _nb_rows(m.nb_rows()), _nb_cols(m.nb_cols()){
 	M = new Vector[_nb_rows];
 	for (int i=0; i<_nb_rows; i++) {

--- a/src/arithmetic/ibex_Matrix.h
+++ b/src/arithmetic/ibex_Matrix.h
@@ -14,6 +14,7 @@
 
 #include "ibex_Vector.h"
 #include <iostream>
+#include <initializer_list>
 
 namespace ibex {
 
@@ -54,6 +55,13 @@ public:
 	 * \pre m>0, n>0
 	 */
 	Matrix(int m, int n, double x[]);
+
+	/**
+	 * Create a matrix from a list of Vector.
+	 *
+	 * \pre x.size() > 0, all Vectors of x must be of the same size.
+	 */
+	Matrix(std::initializer_list<Vector> x);
 
 	/**
 	 * \brief Delete *this.

--- a/src/arithmetic/ibex_Vector.cpp
+++ b/src/arithmetic/ibex_Vector.cpp
@@ -1,5 +1,5 @@
 //============================================================================
-//                                  I B E X                                   
+//                                  I B E X
 // File        : ibex_Vector.cpp
 // Author      : Gilles Chabert
 // Copyright   : Ecole des Mines de Nantes (France)
@@ -18,6 +18,12 @@ namespace ibex {
 Vector::Vector(int nn) : n(nn), vec(new double[nn]) {
 	assert(nn>=1);
 	for (int i=0; i<nn; i++) vec[i]=0;
+}
+
+Vector::Vector(std::initializer_list<double> list): n(list.size()) {
+	assert(n >= 1);
+	vec = new double[n];
+	std::copy(list.begin(), list.end(), vec);
 }
 
 Vector::Vector(int nn, double x) : n(nn), vec(new double[nn]) {

--- a/src/arithmetic/ibex_Vector.h
+++ b/src/arithmetic/ibex_Vector.h
@@ -1,5 +1,5 @@
 //============================================================================
-//                                  I B E X                                   
+//                                  I B E X
 // File        : ibex_Vector.h
 // Author      : Gilles Chabert
 // Copyright   : Ecole des Mines de Nantes (France)
@@ -13,6 +13,7 @@
 
 #include <cassert>
 #include <iostream>
+#include <initializer_list>
 
 namespace ibex {
 
@@ -36,6 +37,13 @@ public:
 	 * \pre n>0
 	 */
 	Vector(int n);
+
+	/**
+	 * \brief Create a vector from a list of double.
+	 *
+	 * \pre list not empty
+	 */
+	Vector(std::initializer_list<double> list);
 
 	/**
 	 * \brief Create [x; ....; x]

--- a/tests/TestInterval.cpp
+++ b/tests/TestInterval.cpp
@@ -35,6 +35,11 @@ void TestInterval::cons05() {
 	check((Interval())=Interval(1,0), Interval::empty_set());
 } // reverse bounds
 
+void TestInterval::consCppArray() {
+	check(Interval{1.0}, Interval(1.0, 1.0));
+	check(Interval{1.0, 2.0}, Interval(1.0, 2.0));
+}
+
 void TestInterval::check_eq(const Interval& x, const Interval& y, bool is_eq) {
 	CPPUNIT_ASSERT(is_eq? x==y : !(x==y));
 	CPPUNIT_ASSERT(is_eq? !(x!=y) : x!=y);

--- a/tests/TestInterval.h
+++ b/tests/TestInterval.h
@@ -29,6 +29,7 @@ public:
 	CPPUNIT_TEST(cons03);
 	CPPUNIT_TEST(cons04);
 	CPPUNIT_TEST(cons05);
+	CPPUNIT_TEST(consCppArray);
 
 	CPPUNIT_TEST(eq01);
 	CPPUNIT_TEST(eq02);
@@ -191,6 +192,8 @@ private:
 	void cons03();
 	void cons04();
 	void cons05();
+	/* Uses C++ fixed-size array */
+	void consCppArray();
 
 	/* test
 	 * =========

--- a/tests/TestIntervalMatrix.cpp
+++ b/tests/TestIntervalMatrix.cpp
@@ -188,6 +188,14 @@ void TestIntervalMatrix::cons04() {
 	CPPUNIT_ASSERT(m==M1());
 }
 
+void TestIntervalMatrix::consInitList() {
+	IntervalMatrix m{
+		{{0,1}, {0,2}, {0,3}},
+		{{-1,0},{-2,0},{-3,0}}
+	};
+	CPPUNIT_ASSERT(m == M1());
+}
+
 void TestIntervalMatrix::empty01() {
 
 	CPPUNIT_ASSERT(IntervalMatrix::empty(2,3).nb_rows()==2);

--- a/tests/TestIntervalMatrix.h
+++ b/tests/TestIntervalMatrix.h
@@ -35,6 +35,8 @@ public:
 	CPPUNIT_TEST(cons03);
 	CPPUNIT_TEST(cons04);
 
+	CPPUNIT_TEST(consInitList);
+
 	CPPUNIT_TEST(empty01);
 	CPPUNIT_TEST(is_empty01);
 	CPPUNIT_TEST(is_empty02);
@@ -115,6 +117,8 @@ public:
 	void cons03();
 	// test: IntervalMatrix(int m, int n, double x[][2])
 	void cons04();
+	// test: IntervalMatrix(std::initializer_list<IntervalVector>)
+	void consInitList();
 
 	// test: static IntervalMatrix empty(int m, int n)
 	void empty01();

--- a/tests/TestIntervalVector.cpp
+++ b/tests/TestIntervalVector.cpp
@@ -60,13 +60,24 @@ void TestIntervalVector::cons05() {
 	CPPUNIT_ASSERT((IntervalVector(2)=x).is_empty());
 }
 
+void TestIntervalVector::consInitList() {
+	IntervalVector x{
+		{1.0, 2.0},
+		{2.0, 3.0},
+		{4}
+	};
+	CPPUNIT_ASSERT(x.size() == 3);
+	CPPUNIT_ASSERT(x[0] == Interval(1.0, 2.0));
+	CPPUNIT_ASSERT(x[1] == Interval(2.0, 3.0));
+	CPPUNIT_ASSERT(x[2] == Interval(4.0, 4.0));
+}
+
 void TestIntervalVector::set_empty01() {
 	IntervalVector x(2);
 	CPPUNIT_ASSERT(!x.is_empty());
 	x.set_empty();
 	CPPUNIT_ASSERT(x.is_empty());
 }
-
 
 void TestIntervalVector::is_empty01() {
 	CPPUNIT_ASSERT(IntervalVector::empty(2).is_empty());

--- a/tests/TestIntervalVector.h
+++ b/tests/TestIntervalVector.h
@@ -30,6 +30,7 @@ public:
 	CPPUNIT_TEST(cons03);
 	CPPUNIT_TEST(cons04);
 	CPPUNIT_TEST(cons05);
+	CPPUNIT_TEST(consInitList);
 
 	CPPUNIT_TEST(set_empty01);
 
@@ -190,6 +191,8 @@ public:
 	void cons04();
 	// test: empty(int n)
 	void cons05();
+	// test: IntervalVector(std::initializer_list<Interval>)
+	void consInitList();
 	// test: set_empty()
 	void set_empty01();
 


### PR DESCRIPTION
Salut,

J'ai ajouté les constructeurs avec initializer_list à Vector, IntervalVector, Matrix et IntervalMatrix,
et des constructeurs utilisant std::array<double, 1> et std::array<double, 2> à Interval.
Ça permet d'écrire des choses du genre :
`IntervalVector v{{1.0, 2.0}, {2.0, 3.0}, {4}};`.

J'ai ajouté des tests, et ça passe.