### PR TITLE
Add SIGINT handling in Solver on POSIX systems

### DIFF
--- a/src/bin/ibexsolve.cpp
+++ b/src/bin/ibexsolve.cpp
@@ -13,7 +13,7 @@
 
 #include "ibex.h"
 #include "ibexsolve.h"
-
+#include "ibex_signals.h"
 #include <sstream>
 
 using namespace std;
@@ -223,6 +223,11 @@ int main(int argc, char** argv) {
 		if (!quiet)
 			cout << "running............" << endl << endl;
 
+#ifdef IBEX_SIGNALS
+		ibex::signals::set_catch_SIGINT(true);
+		s.allow_sigint = true;
+#endif
+
 		// Get the solutions
 		if (input_file)
 			s.solve(input_file.Get().c_str());
@@ -257,3 +262,4 @@ int main(int argc, char** argv) {
 		cout << e << endl;
 	}
 }
+

--- a/src/data/ibex_CovSolverData.cpp
+++ b/src/data/ibex_CovSolverData.cpp
@@ -188,6 +188,8 @@ ifstream* CovSolverData::read(const char* filename, CovSolverData& cov, std::sta
 		case 2: cov.data->_solver_solver_status = (unsigned int) Solver::NOT_ALL_VALIDATED; break;
 		case 3: cov.data->_solver_solver_status = (unsigned int) Solver::TIME_OUT;          break;
 		case 4: cov.data->_solver_solver_status = (unsigned int) Solver::CELL_OVERFLOW;     break;
+		case 5: cov.data->_solver_solver_status = (unsigned int) Solver::USER_ABORT;     	break;
+
 		default: ibex_error("[CovSolverData]: invalid solver status.");
 		}
 

--- a/src/solver/ibex_Solver.h
+++ b/src/solver/ibex_Solver.h
@@ -1,5 +1,5 @@
 //============================================================================
-//                                  I B E X                                   
+//                                  I B E X
 // File        : ibex_Solver.h
 // Author      : Gilles Chabert
 // Copyright   : IMT Atlantique (France)
@@ -47,7 +47,7 @@ public:
 	 *
 	 * See comments for solve(...) below.
 	 */
-	typedef enum { SUCCESS, INFEASIBLE, NOT_ALL_VALIDATED, TIME_OUT, CELL_OVERFLOW } Status;
+	typedef enum { SUCCESS, INFEASIBLE, NOT_ALL_VALIDATED, TIME_OUT, CELL_OVERFLOW, USER_ABORT } Status;
 
 	/**
 	 * \brief Boundary test strength
@@ -90,7 +90,7 @@ public:
 	 * \brief Solve the system (non-interactive mode).
 	 *
 	 * \param init_box - the initial box (the search space)
-	 * 
+	 *
 	 * \return Possible values:
 	 *
 	 *   SUCCESS:           (complete search) all solutions found and all
@@ -107,6 +107,7 @@ public:
 	 *   CELL_OVERFLOW:     (incomplete search) cell overflow : the number of
 	 *                      cell has exceeded the limit.
 	 *
+	 *   USER_ABORT:		(incomplete search) search has been aborted by the user.
 	 * The vector of "solutions" (output boxes) found by the solver
 	 * are retrieved with #get_solutions().
 	 */
@@ -206,7 +207,7 @@ public:
 	 * generally, a sequence (with or without fixpoint) of different contractors (HC4,
 	 * Acid, Newton, a linear relaxation, ... )
 	 *
-	 */ 
+	 */
 	Ctc& ctc;
 
 	/**
@@ -261,6 +262,12 @@ public:
 	 *       each time a new solution is found, it is printed.
 	 */
 	int trace;
+
+	/**
+	 * \brief Wether SIGINT catching is allowed, using SignalHandler.
+	 * Should always be false in a multithreaded context.
+	 */
+	bool allow_sigint = false;
 
 
 protected:

--- a/wscript
+++ b/wscript
@@ -85,9 +85,13 @@ def configure (conf):
 		conf.env.DEBUG = False
 	for f in flags.split():
 		conf.check_cxx(cxxflags=f, use="IBEX", mandatory=False, uselib_store="IBEX")
-	
+
 	# To fix Windows compilation problem (strdup with std=c++11, see issue #287)
 	conf.check_cxx(cxxflags = "-U__STRICT_ANSI__", uselib_store="IBEX")
+
+	# Check for unistd.h and signal.h compliance
+	conf.check_cxx(header_name="unistd.h", mandatory=False, uselib_store="IBEX")
+	conf.check_cxx(header_name="signal.h", mandatory=False, uselib_store="IBEX")
 
 	# Build as shared lib is asked
 	conf.start_msg ("Ibex will be built as a")


### PR DESCRIPTION
Proposition pour capturer les SIGINT sur les systèmes POSIX, via la fonction `sigaction` du header `<signal.h>` de la norme POSIX.
Des fonctions additionnelles sont définies dans un nouveau header `ibex_signals.h`.
Les gestion des signaux doit être activée manuellement.