### PR TITLE
[cmake] add fPIC option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,5 @@ doc/_build
 **/examples/*
 !**/examples/*cpp
 !**/examples/makefile
+build*/**
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ list (APPEND CMAKE_MODULE_PATH "${MODULE_DIR}")
 message (STATUS "Configuring Ibex ${IBEX_VERSION}")
 include (ibex-config-utils)
 ibex_init_common ()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC"   )
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC"   )
 
 ################################################################################
 # Configure the libraries for interval arithmetic and linear programming

--- a/interval_lib_wrapper/gaol/CMakeLists.txt
+++ b/interval_lib_wrapper/gaol/CMakeLists.txt
@@ -29,7 +29,7 @@ else()
                         PREFIX mathlib-2.1.0
                         URL ${CMAKE_CURRENT_SOURCE_DIR}/3rd/mathlib-2.1.0.tar.gz
                         BUILD_IN_SOURCE 1
-                        CONFIGURE_COMMAND ./configure --prefix=<INSTALL_DIR>
+                        CONFIGURE_COMMAND ./configure --prefix=<INSTALL_DIR> CFLAGS=${CMAKE_C_FLAGS} CXXFLAGS=${CMAKE_CXX_FLAGS}
                         LOG_DOWNLOAD 1
                         LOG_CONFIGURE 1
                         LOG_BUILD 1
@@ -99,13 +99,14 @@ else ()
     set (GAOL_CONFIG_ARGS "${GAOL_CONFIG_ARGS}" "--disable-simd")
   endif ()
   set (GAOL_PATCH "${CMAKE_CURRENT_SOURCE_DIR}/3rd/gaol-4.2.0.all.all.patch")
+  
   ExternalProject_Add (libgaol_3rd
                         PREFIX gaol-4.2.0
                         ${_gaol_depends}
                         URL ${CMAKE_CURRENT_SOURCE_DIR}/3rd/gaol-4.2.0.tar.gz
                         PATCH_COMMAND patch -p1 -i ${GAOL_PATCH}
                         BUILD_IN_SOURCE 1
-                        CONFIGURE_COMMAND ./configure --prefix=<INSTALL_DIR>
+                        CONFIGURE_COMMAND ./configure --prefix=<INSTALL_DIR> CFLAGS=${CMAKE_C_FLAGS} CXXFLAGS=${CMAKE_CXX_FLAGS}
                                       --with-mathlib-include=${MATHLIB_INCDIR}
                                       --with-mathlib-lib=${MATHLIB_LIBDIR}
                                       ${GAOL_CONFIG_ARGS}


### PR DESCRIPTION
ajout de l'option fPIC  pour pouvoir compiler les binding python avec pybind11