### PR TITLE
Update installation info

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -35,12 +35,12 @@ If you are on MacOS and use the `MacPorts`_ package manager, you can install Ibe
 Otherwise, you can install Ibex from source with the following instructions.
 The installation assumes your system meets some `requirements`_.
 
-Save the archive ``ibex-2.8.8.tar.gz`` in some ``Ibex`` folder and::
+Save the archive ``ibex-2.8.9.tgz`` in some ``Ibex`` folder and::
 
-  ~/Ibex/$ tar xvfz ibex-2.8.8.tar.gz 
-  ~/Ibex/$ cd ibex-2.8.8 
-  ~/Ibex/ibex-2.8.8/$ ./waf configure --lp-lib=soplex
-  ~/Ibex/ibex-2.8.8/$ sudo ./waf install
+  ~/Ibex/$ tar xvfz ibex-2.8.9.tgz 
+  ~/Ibex/$ cd ibex-2.8.9
+  ~/Ibex/ibex-2.8.9/$ sudo ./waf configure --lp-lib=soplex
+  ~/Ibex/ibex-2.8.9/$ sudo ./waf install
     
 
 .. warning::
@@ -50,7 +50,7 @@ Save the archive ``ibex-2.8.8.tar.gz`` in some ``Ibex`` folder and::
    
    If you don't accept these terms, you can configure Ibex without Soplex::
 
-     ~/Ibex/ibex-2.8.8/$ ./waf configure
+     ~/Ibex/ibex-2.8.9/$ sudo ./waf configure
   
    **however** the performances will be strongly degraded, especially for the global optimizer. 
 
@@ -83,13 +83,13 @@ Windows
 
   We will assume now that this folder is the root folder of ibex.
 
-- Save the archive ``ibex-2.8.8.tar.gz`` in ``C:\MinGW\msys\1.0\home\[user]\Ibex``
+- Save the archive ``ibex-2.8.9.tgz`` in ``C:\MinGW\msys\1.0\home\[user]\Ibex``
 - Configure Ibex (still in the shell of MinGW)::
 
   ~/Ibex/$ export PATH="$PATH:/c/Python27" 
-  ~/Ibex/$ tar xvfz ibex-2.8.8.tar.gz 
-  ~/Ibex/$ cd ibex-2.8.8 
-  ~/Ibex/ibex-2.8.8/$ ./waf configure --prefix=/c/MinGW/msys/1.0/home/[user]/Ibex/ibex-2.8.8 --lp-lib=soplex
+  ~/Ibex/$ tar xvfz ibex-2.8.9.tgz 
+  ~/Ibex/$ cd ibex-2.8.9
+  ~/Ibex/ibex-2.8.9/$ ./waf configure --prefix=/c/MinGW/msys/1.0/home/[user]/Ibex/ibex-2.8.9 --lp-lib=soplex
   
   **Note:** the paths must be entered in Linux-style (don't use backslash ("\\") as separator).
 
@@ -101,13 +101,13 @@ Windows
    
       If you don't accept these terms, you can configure Ibex without Soplex::
 
-        ~/Ibex/ibex-2.8.8/$ ./waf configure --prefix=/c/MinGW/msys/1.0/home/[user]/Ibex/ibex-2.8.8
+        ~/Ibex/ibex-2.8.9/$ ./waf configure --prefix=/c/MinGW/msys/1.0/home/[user]/Ibex/ibex-2.8.9
   
       **however** the performances will be strongly degraded, especially for the global optimizer. 
      
 - Install Ibex::
 
-  ~/Ibex/ibex-2.8.8/$ ./waf install
+  ~/Ibex/ibex-2.8.9/$ ./waf install
 
 .. note:: 
 
@@ -143,7 +143,7 @@ Configuration options
 
 The full list of options supported by ``waf configure`` can be obtained with::
 
-	~/Ibex/ibex-2.8.8/$ ./waf --help
+	~/Ibex/ibex-2.8.9/$ ./waf --help
 	
 This will display the full list of installed interval/LP libraries and plugins with their specific options,
 as well as benchmarking features.
@@ -163,11 +163,11 @@ In particular, ``waf`` ``configure`` supports the following options:
 
                         Under MinGW::
                         
-                        $ export PATH=$PATH:/c/MinGW/msys/1.0/home/[user]/Ibex/ibex-2.8.8/lib
+                        $ export PATH=$PATH:/c/MinGW/msys/1.0/home/[user]/Ibex/ibex-2.8.9/lib
                         
                         Under a Windows command window::
                         
-                        > set PATH=%PATH%;C:\MinGW\msys\1.0\home\[user]\Ibex\ibex-2.8.8\lib;C:\MinGW\bin
+                        > set PATH=%PATH%;C:\MinGW\msys\1.0\home\[user]\Ibex\ibex-2.8.9\lib;C:\MinGW\bin
                         
                         
 
@@ -228,11 +228,11 @@ In particular, ``waf`` ``configure`` supports the following options:
                     
                         If Ibex is compiled as a shared library, you must also add the libpath of Soplex in ``LD_LIBRARY_PATH``::
 						
-							~/Ibex/ibex-2.8.8/$ export LD_LIBRARY_PATH=[prefix]/lib/:[soplex-path]/lib/
+							~/Ibex/ibex-2.8.9/$ export LD_LIBRARY_PATH=[prefix]/lib/:[soplex-path]/lib/
 					
                         Under Windows, if you run a program from a command window, the ``PATH`` variable must also be updated::
 					
-							> set IBEX_PATH=C:\MinGW\msys\1.0\home\[user]\Ibex\ibex-2.8.8
+							> set IBEX_PATH=C:\MinGW\msys\1.0\home\[user]\Ibex\ibex-2.8.9
 							> set SOPLEX_PATH=...
 							> set PATH=%PATH%;%IBEX_PATH%\lib;%SOPLEX_PATH%\lib;C:\MinGW\bin
 					
@@ -289,22 +289,22 @@ To install ``pkg-config`` under MinGW, follow the steps given `here <http://stac
 
 So, place the file ``foo.cpp`` in the ``examples/`` folder and::
 
-  ~/Ibex/ibex-2.8.8/$ cd examples 
-  ~/Ibex/ibex-2.8.8/examples$ make foo 
-  ~/Ibex/ibex-2.8.8/examples$ ./foo 
+  ~/Ibex/ibex-2.8.9/$ cd examples 
+  ~/Ibex/ibex-2.8.9/examples$ make foo 
+  ~/Ibex/ibex-2.8.9/examples$ ./foo 
   
 .. note::
    
    1. It may be necessary to set the ``PKG_CONFIG_PATH`` to *[prefix]*\ ``/share/pkgconfig`` where *[prefix]* is 
       ``/usr/local`` by default or whatever path specified via ``--prefix``::
 
-        ~/Ibex/ibex-2.8.8/$ export PKG_CONFIG_PATH=/usr/local/share/pkgconfig/ 
+        ~/Ibex/ibex-2.8.9/$ export PKG_CONFIG_PATH=/usr/local/share/pkgconfig/ 
 
 
 Under Windows, if you have compiled Ibex with ``--enable--shared`` you can run the program from a command window. 
 Just update the path to dynamically link against Ibex::
 
-	 > set IBEX_PATH=C:\MinGW\msys\1.0\home\[user]\Ibex\ibex-2.8.8
+	 > set IBEX_PATH=C:\MinGW\msys\1.0\home\[user]\Ibex\ibex-2.8.9
 	 > set PATH=%PATH%;%IBEX_PATH%\lib;C:\MinGW\bin
 	 > cd %IBEX_PATH%\examples
 	 > foo.exe
@@ -316,15 +316,15 @@ You can also run the whole unit tests suite with the **installed** version of Ib
 
 To this end, you must install first the `cppunit library <https://sourceforge.net/projects/cppunit/>`_. Then run::
 
-	~/Ibex/ibex-2.8.8/$ ./waf utest
+	~/Ibex/ibex-2.8.9/$ ./waf utest
 	
 Note also the following command::
 
-	~/Ibex/ibex-2.8.8/$ ./waf check
+	~/Ibex/ibex-2.8.9/$ ./waf check
 	
 as a handy shortcut for::
 
-	~/Ibex/ibex-2.8.8/$ ./waf build install clean utest
+	~/Ibex/ibex-2.8.9/$ ./waf build install clean utest
 
 
 =============
@@ -333,8 +333,8 @@ Uninstall
 
 Simply type in the path of IBEX (under the shell of MinGW for Windows)::
 
-  ~/Ibex/ibex-2.8.8$ sudo ./waf uninstall  
-  ~/Ibex/ibex-2.8.8$ ./waf distclean  
+  ~/Ibex/ibex-2.8.9$ sudo ./waf uninstall  
+  ~/Ibex/ibex-2.8.9$ ./waf distclean  
 
 **Note:** sudo is useless under MinGW or if Ibex is installed in a local folder.
 


### PR DESCRIPTION
- Update all 2.8.8 terms to 2.8.9

- More importantly, add `sudo` before `./waf configure --lp-lib=soplex`. Otherwise, even if it shows "'configure' finished successfully", the next step `sudo ./waf install` will raise an error "The project was not configured: run "waf configure" first!" (tested on Ubuntu). (Note that this issue also exists for 2.8.8).