### PR TITLE
Some minor updates for CMake support on Windows (currently used to build Tubex on Windows)

### DIFF
--- a/cmake.utils/ibex-config-utils.cmake
+++ b/cmake.utils/ibex-config-utils.cmake
@@ -463,8 +463,13 @@ function (IBEX_INIT_COMMON)
     set_property (CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")
   endif ()
 
+  if(MSVC)
+  set (CMAKE_CXX_FLAGS_RELEASE "/D NDEBUG /D _CRT_SECURE_NO_WARNINGS" PARENT_SCOPE)
+  set (CMAKE_CXX_FLAGS_DEBUG "/D DEBUG /D _CRT_SECURE_NO_WARNINGS" PARENT_SCOPE)
+  else()
   set (CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG" PARENT_SCOPE)
   set (CMAKE_CXX_FLAGS_DEBUG "-O0 -g -pg -Wall -DDEBUG" PARENT_SCOPE)
+  endif()
 
   ##############################################################################
   # add uninstall command

--- a/interval_lib_wrapper/CMakeLists.txt
+++ b/interval_lib_wrapper/CMakeLists.txt
@@ -1,7 +1,10 @@
 subdir_list (INTERVAL_LIB_LIST RELATIVE)
 
-# TODO filib on Windows ??
-set(INTERVAL_LIB "gaol" CACHE STRING "Library used for interval arithmetic")
+if(WIN32)
+  set(INTERVAL_LIB "filib" CACHE STRING "Library used for interval arithmetic")
+else()
+  set(INTERVAL_LIB "gaol" CACHE STRING "Library used for interval arithmetic")
+endif()
 set_property(CACHE INTERVAL_LIB PROPERTY STRINGS ${INTERVAL_LIB_LIST})
 
 list(FIND INTERVAL_LIB_LIST ${INTERVAL_LIB} is_valid)

--- a/interval_lib_wrapper/gaol/CMakeLists.txt
+++ b/interval_lib_wrapper/gaol/CMakeLists.txt
@@ -25,6 +25,19 @@ if (MATHLIB_INCDIR AND MATHLIB_LIB)
                                         INCLUDE_DIRECTORIES ${MATHLIB_INCDIR})
 else()
   message (STATUS "Will install and use mathlib from 3rd/ subdirectory")
+  if(MINGW)
+  ExternalProject_Add (libultim_3rd
+                        PREFIX mathlib-2.1.0
+                        URL ${CMAKE_CURRENT_SOURCE_DIR}/3rd/mathlib-2.1.0.tar.gz
+                        BUILD_IN_SOURCE 1
+                        CONFIGURE_COMMAND sh -c "./configure --prefix=<INSTALL_DIR>
+                                                      CFLAGS=${CMAKE_C_FLAGS}"
+                        LOG_DOWNLOAD 1
+                        LOG_CONFIGURE 1
+                        LOG_BUILD 1
+                        LOG_INSTALL 1
+                      )
+  else()
   ExternalProject_Add (libultim_3rd
                         PREFIX mathlib-2.1.0
                         URL ${CMAKE_CURRENT_SOURCE_DIR}/3rd/mathlib-2.1.0.tar.gz
@@ -36,6 +49,7 @@ else()
                         LOG_BUILD 1
                         LOG_INSTALL 1
                       )
+  endif()
   ExternalProject_Get_Property (libultim_3rd INSTALL_DIR)
   set (MATHLIB_LIBDIR "${INSTALL_DIR}/lib")
   set (MATHLIB_INCDIR "${INSTALL_DIR}/include")
@@ -100,6 +114,25 @@ else ()
     set (GAOL_CONFIG_ARGS "${GAOL_CONFIG_ARGS}" "--disable-simd")
   endif ()
   set (GAOL_PATCH "${CMAKE_CURRENT_SOURCE_DIR}/3rd/gaol-4.2.0.all.all.patch")
+  if(MINGW)
+  ExternalProject_Add (libgaol_3rd
+                        PREFIX gaol-4.2.0
+                        ${_gaol_depends}
+                        URL ${CMAKE_CURRENT_SOURCE_DIR}/3rd/gaol-4.2.0.tar.gz
+                        PATCH_COMMAND patch -p1 -i ${GAOL_PATCH}
+                        BUILD_IN_SOURCE 1
+                        CONFIGURE_COMMAND sh -c "./configure --prefix=<INSTALL_DIR>
+                                      CFLAGS=${CMAKE_C_FLAGS}
+                                      CXXFLAGS=${CMAKE_CXX_FLAGS}
+                                      --with-mathlib-include=${MATHLIB_INCDIR}
+                                      --with-mathlib-lib=${MATHLIB_LIBDIR}
+                                      ${GAOL_CONFIG_ARGS}"
+                        LOG_DOWNLOAD 1
+                        LOG_CONFIGURE 1
+                        LOG_BUILD 1
+                        LOG_INSTALL 1
+                      )
+  else()
   ExternalProject_Add (libgaol_3rd
                         PREFIX gaol-4.2.0
                         ${_gaol_depends}
@@ -117,6 +150,7 @@ else ()
                         LOG_BUILD 1
                         LOG_INSTALL 1
                       )
+  endif()
   ExternalProject_Get_Property (libgaol_3rd INSTALL_DIR)
 
   set (_incdir ${INSTALL_DIR}/include)

--- a/lp_lib_wrapper/soplex/CMakeLists.txt
+++ b/lp_lib_wrapper/soplex/CMakeLists.txt
@@ -31,7 +31,7 @@ else ()
                         URL ${CMAKE_CURRENT_SOURCE_DIR}/3rd/soplex-4.0.2.tar
                         PATCH_COMMAND patch -p1 -i ${SOPLEX_PATCH}
                         CONFIGURE_COMMAND ""
-                        BUILD_COMMAND make GMP=false ZLIB=false USRCPPFLAGS=-fPIC INSTALLDIR=<INSTALL_DIR> install
+                        BUILD_COMMAND $(MAKE) GMP=false ZLIB=false USRCPPFLAGS=-fPIC INSTALLDIR=<INSTALL_DIR> install
                         INSTALL_COMMAND ""
                         BUILD_IN_SOURCE 1
                         LOG_DOWNLOAD 1


### PR DESCRIPTION
Some minor updates for CMake support on Windows (currently used to build [Tubex](https://github.com/SimonRohou/tubex-lib/blob/master/.travis.yml) on Windows) : 
- `cmake.utils/ibex-config-utils.cmake` : some parameters are different for Visual Studio
- `interval_lib_wrapper/CMakeLists.txt` : propose `filib` by default for Windows since `gaol` might not always work on Windows
- `interval_lib_wrapper/gaol/CMakeLists.txt` : sometimes `./configure` does not work directly on Windows, we need to put `sh -c "./configure"`
- `lp_lib_wrapper/soplex/CMakeLists.txt` : `$(MAKE)` is sometimes more general than calling directly `make` since it might be e.g. `mingw32-make.exe` that should be called instead...
