### PR TITLE
New linearizer + loupfinders

### DIFF
--- a/examples/abstaylor.cpp
+++ b/examples/abstaylor.cpp
@@ -1,0 +1,75 @@
+/**
+ *
+ * This main shows how to use the upperbounding methods: AbsTaylor and Iterative.
+ *
+ * As output you can expect the feasible point and the cost.
+ */
+#include "ibex.h"
+
+using namespace std;
+using namespace ibex;
+
+
+int main(int argc, char** argv) {
+
+	if (argc < 4){
+		cout << "Use the format: ./abstaylor FILE [abst|iterative] [mid|rnd]" << endl;
+		return 0;
+	}
+	System *sys;
+	pair<IntervalVector,double> p;
+	sys = new System(argv[1]);
+	string loup_finder = argv[2];
+	string exp_point= argv[3];
+	LinearizerXTaylor* lr = new LinearizerXTaylor(*sys,LinearizerXTaylor::RESTRICT,LinearizerXTaylor::RANDOM);
+
+
+	//Point definition, either mid or random
+	LinearizerAbsTaylor* lr2;
+
+	if (exp_point == "mid")
+		lr2 = new LinearizerAbsTaylor(*sys,LinearizerAbsTaylor::MID);
+	else if (exp_point == "rnd"){
+		lr2 = new LinearizerAbsTaylor(*sys,LinearizerAbsTaylor::RANDOM);
+		}
+	else{
+		cout << "Use either mid for the midpoint or rnd for a random point inside the box" << endl;
+		exit(1);
+	}
+
+	cout << endl<<"The search of upperbounds will be performed in the box : "<< sys->box << endl<<endl;
+	cout << "Press a key to continue"<< endl;
+	string aux; cin >> aux;
+//
+	//abstaylor section
+	LoupFinderIP* finder_ip_abst = new LoupFinderIP(*sys,lr2);
+
+	if (loup_finder == "abst"){
+		try {
+			p = finder_ip_abst->find(sys->box,sys->box.mid(),POS_INFINITY);
+			cout << "The point :    ";
+			cout << p.first.ub() << endl;
+			cout << "corresponds to an upperbound of the problem with a cost of ";
+			cout << p.second << endl << endl;
+
+		} catch(LoupFinder::NotFound&) {cout << "Upperbound not found"<<endl; }
+	}
+//
+	//iterative section
+	else if (loup_finder == "iterative"){
+		LoupFinderIP* finder_ip_xt = new LoupFinderIP(*sys,lr);
+		vector<LoupFinderIP*> finders;
+		finders.push_back(finder_ip_abst); finders.push_back(finder_ip_xt);
+		LoupFinderIterative* finder_trust = new LoupFinderIterative(*sys,sys->box,finders);
+		try {
+			finder_trust->set_trace(true);
+			finder_trust->find(sys->box,sys->box.mid(),POS_INFINITY);
+		} catch(LoupFinder::NotFound&) {cout << "Upperbound not found"<<endl; }
+	}
+	else{
+		cout << "Method not found!" << endl;
+		exit(1);
+	}
+
+
+}

--- a/src/loup/ibex_LoupFinderDefault.h
+++ b/src/loup/ibex_LoupFinderDefault.h
@@ -12,7 +12,8 @@
 
 #include "ibex_LoupFinder.h"
 #include "ibex_System.h"
-#include "ibex_LoupFinderXTaylor.h"
+#include "ibex_LoupFinderIterative.h"
+#include "ibex_LoupFinderIP.h"
 
 namespace ibex {
 
@@ -79,9 +80,9 @@ public:
 	LoupFinder& finder_probing;
 
 	/**
-	 * Loup finder using inner polytopes.
-	 */
-	LoupFinderXTaylor finder_x_taylor;
+	 * Loup finder using inner polytopes, which uses the XTaylor linearization.
+	*/
+	LoupFinderIP* finder_x_taylor;
 };
 
 inline std::pair<IntervalVector, double> LoupFinderDefault::find(const IntervalVector& box, const IntervalVector& loup_point, double loup) {

--- a/src/loup/ibex_LoupFinderIP.cpp
+++ b/src/loup/ibex_LoupFinderIP.cpp
@@ -1,31 +1,32 @@
-	//============================================================================
-//                                  I B E X
-// File        : ibex_LoupFinderXTaylor.cpp
-// Author      : Gilles Chabert, Ignacio Araya, Bertrand Neveu
-// Copyright   : IMT Atlantique (France)
-// License     : See the LICENSE file
-// Created     : Jul 12, 2012
-// Last Update : Jul 09, 2017
-//============================================================================
+/* ============================================================================
+ * I B E X - Inner Polytope loup finder
+ * ============================================================================
+ *
+ * Author(s)   : Ignacio Araya, Victor Reyes
+ * Created     : April 2021
+ * Updated     : April 2021
+ * ---------------------------------------------------------------------------- */
 
-#include "ibex_LoupFinderXTaylor.h"
+#include "ibex_LoupFinderIP.h"
+#include <stdio.h>
+#include <string>
 
 using namespace std;
 
 namespace ibex {
 
 //TODO: remove this recipe for the argument of the max number of iterations of the LP solver
-LoupFinderXTaylor::LoupFinderXTaylor(const System& sys) : sys(sys), lr(sys,LinearizerXTaylor::RESTRICT,LinearizerXTaylor::RANDOM), lp_solver(sys.nb_var) {
+LoupFinderIP::LoupFinderIP(const System& sys, Linearizer* lr) : sys(sys), lp_solver((dynamic_cast<LinearizerXTaylor*>(lr))? sys.nb_var:(2*sys.nb_var)),lr(lr) {
 	lp_solver.set_max_iter(std::min(sys.nb_var*3, int(LPSolver::default_max_iter)));
-//	nb_simplex=0;
-//	diam_simplex=0;
+
 }
 
-void LoupFinderXTaylor::add_property(const IntervalVector& init_box, BoxProperties& prop) {
-	lr.add_property(init_box,prop);
+void LoupFinderIP::add_property(const IntervalVector& init_box, BoxProperties& prop) {
+	lr->add_property(init_box,prop);
 }
 
-std::pair<IntervalVector, double> LoupFinderXTaylor::find(const IntervalVector& box, const IntervalVector&, double current_loup, BoxProperties& prop) {
+std::pair<IntervalVector, double> LoupFinderIP::find(const IntervalVector& box, const IntervalVector&, double current_loup, BoxProperties& prop) {
+
 
 	int n=sys.nb_var;
 
@@ -33,7 +34,6 @@ std::pair<IntervalVector, double> LoupFinderXTaylor::find(const IntervalVector& 
 		throw NotFound();
 
 	lp_solver.clear_constraints();
-	lp_solver.set_bounds(box);
 
 	IntervalVector ig=sys.goal->gradient(box.mid());
 	if (ig.is_empty()) // unfortunately, at the midpoint the function is not differentiable
@@ -46,7 +46,7 @@ std::pair<IntervalVector, double> LoupFinderXTaylor::find(const IntervalVector& 
 	for (int j=0; j<n; j++)
 		lp_solver.set_cost(j,g[j]);
 
-	int count = lr.linearize(box,lp_solver,prop);
+	int count = lr->linearize(box,lp_solver,prop);
 
 	if (count==-1) {
 		lp_solver.clear_constraints();
@@ -57,11 +57,12 @@ std::pair<IntervalVector, double> LoupFinderXTaylor::find(const IntervalVector& 
 	if (stat == LPSolver::Status::Optimal) {
 		//the linear solution is mapped to intervals and evaluated
 		Vector loup_point = lp_solver.not_proved_primal_sol();
-
+		loup_point.resize(box.size()); //for abstaylor
 		// we allow a loup to be outside of the current box, but
 		// not outside of the system box.
 		// To deal with the latter case, we apply the following
 		// simple change to the loup point (which would be lost anyway)
+
 		for (uint i=0; i<n; i++) {
 			if (loup_point[i] < sys.box[i].lb()) loup_point[i] = sys.box[i].lb();
 			if (loup_point[i] > sys.box[i].ub()) loup_point[i] = sys.box[i].ub();

--- a/src/loup/ibex_LoupFinderIP.h
+++ b/src/loup/ibex_LoupFinderIP.h
@@ -1,43 +1,38 @@
-//============================================================================
-//                                  I B E X
-// File        : ibex_LoupFinderXTaylor.h
-// Author      : Gilles Chabert, Ignacio Araya, Bertrand Neveu
-// Copyright   : IMT Atlantique (France)
-// License     : See the LICENSE file
-// Created     : Jul 12, 2012
-// Last Update : Jul 09, 2017
-//============================================================================
 
-#ifndef __IBEX_LOUP_FINDER_X_TAYLOR_H__
-#define __IBEX_LOUP_FINDER_X_TAYLOR_H__
+#ifndef __IBEX_LOUP_FINDER_IP_H__
+#define __IBEX_LOUP_FINDER_IP_H__
 
 #include "ibex_LinearizerXTaylor.h"
+#include "ibex_LinearizerAbsTaylor.h"
+
+
 #include "ibex_LoupFinder.h"
 #include "ibex_LPSolver.h"
 
 namespace ibex {
 /**
- * \ingroup optim
  *
- * \brief Upper-bounding algorithm based on XTaylor restriction.
+ * \brief Upper-bounding algorithm based on finding inner feasible polytopes.
  *
  * The algorithm builds an inner (feasible) polytope inside the
- * current box (see #LinearizerXTaylor) and then minimizes a
+ * current box (see #LinearizerXTaylor and #LinearizerAbsTaylor) and then minimizes a
  * linear approximation of the goal function on this polytope via
  * a LP solver. The resulting point is verified a posteriori to
  * be feasible (wrt nonlinear constraint) and a new "loup".
  *
  * \note Only works with inequality constraints.
  */
-class LoupFinderXTaylor : public LoupFinder {
+class LoupFinderIP : public LoupFinder {
+
 public:
 
 	/**
 	 * \brief Create the algorithm for a given system.
 	 *
 	 * \param sys         - The NLP problem.
+	 * \param lr          - The linearization method.
 	 */
-	LoupFinderXTaylor(const System& sys);
+	LoupFinderIP(const System& sys, Linearizer* lr);
 
 	/**
 	 * \brief Find a new loup in a given box.
@@ -57,34 +52,27 @@ public:
 	 * \brief Add properties required by this loup finder.
 	 */
 	virtual void add_property(const IntervalVector& init_box, BoxProperties& prop);
-
 	/**
 	 * \brief The NLP problem.
 	 */
 	const System& sys;
+private:
 
 protected:
-
 	/** Linearization technique. */
-	LinearizerXTaylor lr;
+	Linearizer* lr;
 
 	/** linear solver */
 	LPSolver lp_solver;
-
-	/** Miscellaneous   for statistics */
-//	int nb_simplex;
-//	double diam_simplex;
 };
 
 /*============================================ inline implementation ============================================ */
 
-inline std::pair<IntervalVector, double> LoupFinderXTaylor::find(const IntervalVector& box, const IntervalVector& loup_point, double loup) {
+inline std::pair<IntervalVector, double> LoupFinderIP::find(const IntervalVector& box, const IntervalVector& loup_point, double loup) {
 	BoxProperties prop(box);
 	return find(box, loup_point, loup, prop);
 }
 
 } /* namespace ibex */
 
-
-
-#endif /* __IBEX_LOUP_FINDER_X_TAYLOR_H__ */
+#endif /* __IBEX_LOUP_FINDER_IP_H__ */

--- a/src/loup/ibex_LoupFinderIterative.cpp
+++ b/src/loup/ibex_LoupFinderIterative.cpp
@@ -1,0 +1,110 @@
+/* ============================================================================
+ * I B E X - Iterative loup finder
+ * ============================================================================
+ *
+ * Author(s)   : Ignacio Araya, Victor Reyes
+ * Created     : May 2021
+ * Updated     : May 2021
+ * ---------------------------------------------------------------------------- */
+
+#include "ibex_LoupFinderIterative.h"
+
+using namespace std;
+
+namespace ibex {
+
+
+LoupFinderIterative::LoupFinderIterative(const System& sys,const IntervalVector& initial_box,std::vector<LoupFinderIP*> loup_finders,double alpha,int max_iter,double prec) :
+	initial_box(initial_box),alpha(alpha),sys(sys),max_iter(max_iter),prec(prec),trace(false),loup_finders(loup_finders) {
+
+	if (loup_finders.size() == 0) get_default_finders(LoupFinderIterative::loup_finders);
+}
+
+void LoupFinderIterative::get_default_finders(std::vector<LoupFinderIP*> & loup_finders){
+	LinearizerXTaylor* lr = new LinearizerXTaylor(sys,LinearizerXTaylor::RESTRICT,LinearizerXTaylor::RANDOM);
+	LinearizerAbsTaylor* lr2 = new LinearizerAbsTaylor(sys);
+	LoupFinderIP* finder_ip_abst = new LoupFinderIP(sys,lr2); LoupFinderIP* finder_ip_xt = new LoupFinderIP(sys,lr);
+	loup_finders.push_back(finder_ip_abst); loup_finders.push_back(finder_ip_xt);
+}
+
+
+void LoupFinderIterative::reduce_and_move(IntervalVector& box_aux, Vector old_exp){
+	for (int i = 0 ; i < box_aux.size() ; i++){
+		if ((old_exp[i]-(alpha)*box_aux[i].diam()/2>=initial_box[i].lb()) && (old_exp[i]+(alpha)*box_aux[i].diam()/2<=initial_box[i].ub()))
+			box_aux[i] = Interval(old_exp[i]-(alpha)*box_aux[i].diam()/2,old_exp[i]+(alpha)*box_aux[i].diam()/2);
+		else if ((old_exp[i]-(alpha)*box_aux[i].diam()/2>=initial_box[i].lb()) && (old_exp[i]+(alpha)*box_aux[i].diam()/2>initial_box[i].ub()))
+			box_aux[i] = Interval(old_exp[i]-(alpha)*box_aux[i].diam()/2,initial_box[i].ub());
+		else if ((old_exp[i]-(alpha)*box_aux[i].diam()/2<initial_box[i].lb()) && (old_exp[i]+(alpha)*box_aux[i].diam()/2<=initial_box[i].ub()))
+			box_aux[i] = Interval(initial_box[i].lb(),old_exp[i]+(alpha)*box_aux[i].diam()/2);
+		else if ((old_exp[i]-alpha*box_aux[i].diam()/2<initial_box[i].lb()) && (old_exp[i]+alpha*box_aux[i].diam()/2>initial_box[i].ub()))
+			box_aux[i] = Interval(initial_box[i].lb(),initial_box[i].ub());
+	}
+}
+
+void LoupFinderIterative::print_ub(std::pair<IntervalVector,double> p){
+	cout << "The point :    ";
+	cout << p.first.ub() << endl;
+	cout << "corresponds to an upperbound of the problem with a cost of ";
+	cout << p.second << endl << endl;
+}
+
+std::pair<IntervalVector, double> LoupFinderIterative::find(const IntervalVector& box, const IntervalVector& old_point, double old_loup) {
+
+	pair<IntervalVector,double> p=make_pair(old_point, old_loup);
+
+	bool found=false;
+	pair<IntervalVector,double> new_ub = p;
+	pair<IntervalVector,double> old_ub = p;
+ 	bool flag = true;
+
+ 	for (int i = 0 ; i < loup_finders.size() ; i++){
+		try{
+			pair<IntervalVector,double> new_ub=loup_finders[i]->find(box,old_point,p.second);
+			if(new_ub.second < p.second){
+				found = true;
+				p = new_ub;
+				if (trace) print_ub(p);
+			}
+			else throw NotFound();
+		} catch(NotFound&) { }
+ 	}
+
+	if (!found){
+		throw NotFound();
+	}
+	IntervalVector box_aux(box.size());
+	box_aux = box;
+	int nb_iter = 0;
+	while ((old_ub.second-p.second > prec) || (flag)){
+		if (old_ub.second-p.second < prec) flag = false;
+		else flag = true;
+
+		Vector old_exp = p.first.mid();
+		reduce_and_move(box_aux,old_exp);
+		old_ub = p;
+
+		try {
+			new_ub=loup_finders[0]->find(box_aux,p.first,p.second);
+			if(new_ub.second < p.second){
+				p = new_ub;
+				if (trace) print_ub(p);
+			}
+		} catch(NotFound&) {}
+
+		nb_iter++;
+		if (nb_iter >= max_iter)
+			break;
+	}
+	if (found){
+		return p;
+	}
+	else
+		throw NotFound();
+}
+
+
+LoupFinderIterative::~LoupFinderIterative() {
+
+}
+
+} /* namespace ibex */

--- a/src/loup/ibex_LoupFinderIterative.h
+++ b/src/loup/ibex_LoupFinderIterative.h
@@ -1,0 +1,101 @@
+/* ============================================================================
+ * I B E X - Iterative loup finder
+ * ============================================================================
+ *
+ * Author(s)   : Ignacio Araya, Victor Reyes
+ * Created     : May 2021
+ * Updated     : May 2021
+ * ---------------------------------------------------------------------------- */
+
+
+#ifndef __IBEX_LOUP_FINDER_ITERATIVE_H__
+#define __IBEX_LOUP_FINDER_ITERATIVE_H__
+
+#include "ibex_LoupFinder.h"
+#include "ibex_System.h"
+#include "ibex_LoupFinderIP.h"
+#include "ibex_Vector.h"
+
+namespace ibex {
+
+class LoupFinderIterative : public LoupFinder {
+
+	/**
+	 * \ingroup optim
+	 *
+	 * \brief An iterative algorithm based on XTaylor and/or AbsTaylor.
+	 *
+	 * The algorithm builds an inner (feasible) polytope inside the
+	 * current box by using either AbsTaylor or XTaylor; and then minimizes a
+	 * linear approximation of the goal function on this polytope via
+	 * a LP solver. If the algorithm success, then it construct a new box (inside the
+	 * search space), continuing the search of better upperbounds.
+	 *
+	 * For more details check the paper: Reyes, V., & Araya, I. (2021). AbsTaylor: upper
+	 * bounding with inner regions in nonlinear continuous global optimization problems.
+	 */
+
+public:
+
+	/**
+	 * \brief Create the algorithm for a given system.
+	 *
+	 * \param sys   - The NLP problem.
+	 * \param initial_box - The initial search space.
+	 * \param loup_finder - List of loup finders. The complete list is used to find a first loup. Then
+	 * 						the first element of the list is used during the iteration process.
+	 * \param alpha  - parameter to reduce the box
+	 * \param max_iter - maximum number of iterations
+	 * \param prec - the precision of the algorithm
+	 */
+
+	LoupFinderIterative(const System& sys, const IntervalVector& initial_box,std::vector<LoupFinderIP*> loup_finders=std::vector<LoupFinderIP*>(0), double alpha=0.9,int max_iter=10, double prec=1e-3);
+
+	/**
+	 * \brief Delete this.
+	 */
+	virtual ~LoupFinderIterative();
+
+	/**
+	 * \brief Find a new loup in a given box and the neighborhood by using
+	 * a LoupFinder (e.g. AbsTaylor/XTaylor).
+	 */
+	virtual std::pair<IntervalVector, double> find(const IntervalVector& box, const IntervalVector& loup_point, double loup);
+	/**
+	 * \brief To use for checking the progress of the upperbounds
+	 */
+	void set_trace(bool trace){this->trace = trace;}
+	/**
+	 * \brief For printing the ub, in case the trace function is active
+	 */
+	void print_ub(std::pair<IntervalVector,double> p);
+	/**
+	 * \brief Changes the size and position of the current search box. Always inside
+	 * the root box.
+	 */
+	void reduce_and_move(IntervalVector& box_aux, Vector old_exp);
+	/*
+	 * \brief This function constructs the list of the "default" loop finders.
+	 */
+	void get_default_finders(std::vector<LoupFinderIP*> & loup_finders);
+	/**The system**/
+	const System& sys;
+private:
+
+	/**LoupFinder IP - AbsTaylor/XTaylor**/
+	std::vector<LoupFinderIP*> loup_finders;
+	/**The initial box (search space)**/
+	const IntervalVector& initial_box;
+	/**User parameter for convergence purposes**/
+	double alpha;
+	/*maximum number of iterations*/
+	int max_iter;
+	/*the precision */
+	double prec;
+	/*trace, just for testing & example purposes*/
+	bool trace;
+};
+
+} /* namespace ibex */
+
+#endif /* __IBEX_LOUP_FINDER_ITERATIVE_H__ */

--- a/src/numeric/ibex_LinearizerAbsTaylor.cpp
+++ b/src/numeric/ibex_LinearizerAbsTaylor.cpp
@@ -1,0 +1,172 @@
+/* ============================================================================
+ * I B E X - AbsTaylor linearizer
+ * ============================================================================
+ *
+ * Author(s)   : Ignacio Araya, Victor Reyes
+ * Created     : May 2021
+ * Updated     : May 2021
+ * ---------------------------------------------------------------------------- */
+
+#include "ibex_LinearizerAbsTaylor.h"
+#include "ibex_ExtendedSystem.h"
+#include "ibex_Random.h"
+#include "ibex_Exception.h"
+#include "ibex_NormalizedSystem.h"
+
+#include <vector>
+
+using namespace std;
+
+namespace ibex {
+
+namespace {
+	class Unsatisfiability : public Exception { };
+	class NoExpansionPoint : public Exception { };
+}
+
+LinearizerAbsTaylor::LinearizerAbsTaylor(const System& _sys, point_policy point):
+		Linearizer(_sys.nb_var), sys(_sys),
+			m(sys.f_ctrs.image_dim()), goal_ctr(-1 /*tmp*/),
+			lp_solver(NULL), point(point) {
+
+	if (dynamic_cast<const ExtendedSystem*>(&sys)) {
+		((int&) goal_ctr)=((const ExtendedSystem&) sys).goal_ctr();
+	}
+
+}
+
+LinearizerAbsTaylor::~LinearizerAbsTaylor() {
+
+}
+
+int LinearizerAbsTaylor::linearize(const IntervalVector& box, LPSolver& _lp_solver)  {
+	lp_solver = &_lp_solver;
+	IntervalVector box2(n*2);
+	for(int i=0;i<n;i++)
+		box2[i]=box[i];
+	//initialize auxiliary variables u_i
+	for(int i=0;i<n;i++)
+		box2[n+i]=Interval(-box2[i].mag(), box2[i].mag());
+	lp_solver->set_bounds(box2);
+	return linear_restrict(box);
+}
+
+int LinearizerAbsTaylor::linear_restrict(const IntervalVector& box) {
+
+	// expansion point
+	Vector exp_point(box.size());
+	if (point == MID)
+		exp_point = box.mid();
+	else if (point == RANDOM){
+		for (int i = 0 ; i < box.size() ; i++)
+			exp_point[i] = RNG::rand(box[i].lb(),box[i].ub());
+	}
+
+	BitSet active=sys.active_ctrs(box);
+	if (active.empty()) return 0;
+
+	try {
+
+		IntervalMatrix J=sys.f_ctrs.jacobian(box,active);
+		//IntervalMatrix J=sys.active_ctrs_jacobian(box);  // --> better with SystemBox
+
+		if (J.is_empty()) return -1; // note: no way to inform that the box is actually infeasible
+
+		IntervalVector g_mid(sys.f_ctrs.eval_vector(exp_point,active));
+		if (g_mid.is_empty()) return -1;
+
+		// total number of added constraint
+		// may be less than active.size() if
+		// a constraint was not detected as inactive
+		int count=0;
+		int c; // constraint number
+
+		for (int i=0; i<active.size(); i++) {
+			c=(i==0? active.min() : active.next(c));
+
+			try {
+				if (sys.ops[c]==EQ && c!=goal_ctr)
+					// in principle we could deal with linear constraints
+					return -1;
+				else if (c==goal_ctr || sys.ops[c]==LEQ || sys.ops[c]==LT)
+					count += linearize_leq_mid(box,exp_point, J[i],g_mid[i]);
+				else
+					count += linearize_leq_mid(box, exp_point, -J[i],-g_mid[i]);
+			} catch (LPException&) {
+				return -1;
+			} catch (Unsatisfiability&) {
+				return -1;
+			}
+		}
+
+		//adding constraints: -(xi - xi_mid) <= Ui, (xi - xi_mid) <= Ui
+		for(int i=0; i<n; i++){
+			Vector a=Vector::zeros(2*n);
+			a[i]=-1.0;
+			a[n+i]=-1.0;
+
+			Vector a2=Vector::zeros(2*n);
+			a2[i]=1.0;
+			a2[n+i]=-1.0;
+
+
+			lp_solver->add_constraint(a, LEQ, -exp_point[i] );
+			lp_solver->add_constraint(a2, LEQ, exp_point[i] );
+			count +=2;
+		}
+
+		return count;
+	} catch(NoExpansionPoint&) {
+		return -1;
+	}
+
+}
+
+
+int LinearizerAbsTaylor::linearize_leq_mid(const IntervalVector& box, const Vector& point, const IntervalVector& dg_box, const Interval& g_mid) {
+	Vector a(2*n); // vector of coefficients
+
+	// ========= compute matrix of coefficients ===========
+	// Fix each coefficient to the lower/upper bound of the
+	// constraint gradient, depending on the position of the
+	// corresponding component of the corner and the
+	// linearization mode.
+	for (int j=0; j<n; j++){
+		a[j]=dg_box[j].mid();
+	}
+
+	for (int j=n; j<2*n; j++){
+		a[j]=(dg_box[j-n]-a[j-n]).mag();
+	}
+
+	// =====================================================
+    Vector aa=a;
+	aa.resize(box.size());
+	Interval rhs = -g_mid + aa*point - lp_solver->tolerance();
+
+	double b = rhs.lb() ;
+
+	// may throw Unsatisfiability and LPException
+	return check_and_add_constraint(box,a,b);
+}
+
+int LinearizerAbsTaylor::check_and_add_constraint(const IntervalVector& box, const Vector& a, double b) {
+
+	Interval ax=a*box; // for fast (in)feasibility check
+
+	// ======= Quick (in)feasibility checks
+	//                 a*[x] <= rhs ?
+	if (ax.lb()>b)
+		// the constraint is not satisfied
+		throw Unsatisfiability();
+	else if (ax.ub()<=b) {
+		// the (linear) constraint is satisfied for any point in the box
+		return 0;
+	} else {
+		//cout << "add constraint " << a << "*x<=" << b << endl;
+		lp_solver->add_constraint(a, LEQ, b);
+		return 1;
+	}
+}
+
+} // end namespace

--- a/src/numeric/ibex_LinearizerAbsTaylor.h
+++ b/src/numeric/ibex_LinearizerAbsTaylor.h
@@ -1,0 +1,107 @@
+/* ============================================================================
+ * I B E X - AbsTaylor linearizer
+ * ============================================================================
+ *
+ * Author(s)   : Ignacio Araya, Victor Reyes
+ * Created     : May 2021
+ * Updated     : May 2021
+ * ---------------------------------------------------------------------------- */
+
+#ifndef __IBEX_LINEARIZER_ABS_TAYLOR__
+#define __IBEX_LINEARIZER_ABS_TAYLOR__
+
+#include "ibex_Linearizer.h"
+#include "ibex_System.h"
+
+
+namespace ibex {
+
+/**
+ * \ingroup numeric
+ *
+ * \brief AbsTaylor linearization technique.
+ *
+ * This class is an implementation of the AbsTaylor algorithm
+ *
+ * \see  Reyes, V., & Araya, I. (2021). AbsTaylor: upper
+ * bounding with inner regions in nonlinear continuous global optimization problems.
+ * Journal of Global Optimization, 79(2), 413-429.
+ *
+ */
+class LinearizerAbsTaylor : public Linearizer {
+
+public:
+	/**
+	 * \brief Policy for selecting the expansion point.
+	 *
+	 * - MID        - The mid point of the box
+	 * - RANDOM     - A random point inside the box
+	 */
+	typedef enum  {MID, RANDOM} point_policy;
+	/**
+	 * \brief Creates the X_Taylor linearizer.
+	 *
+	 * \param sys             - The system (extended or not).
+	 */
+	LinearizerAbsTaylor(const System& sys, point_policy = MID);
+
+	/**
+	 * \brief Deletes this.
+	 */
+	~LinearizerAbsTaylor();
+
+	/**
+	 * \brief Generation of the linear inequalities
+	 *
+	 * \param box             - The current box
+	 * \param lp_solver       - The linear solver.
+	 */
+	virtual int linearize(const IntervalVector& box, LPSolver& lp_solver);
+
+private:
+
+	/**
+	 * \brief Linearization (RESTRICT mode)
+	 */
+	int linear_restrict(const IntervalVector& box);
+
+	/**
+	 * \brief Linearize a constraint g(x)<=0 inside a box, from the midpoint.
+	 *
+	 * \param dg_box:   dg([box])
+	 * \param g_mid: g(mid)
+	 */
+	int linearize_leq_mid(const IntervalVector& box, const Vector& point, const IntervalVector& dg_box, const Interval& g_mid);
+
+	/**
+	 * \brief Add the constraint ax<=b in the LP solver.
+	 */
+	int check_and_add_constraint(const IntervalVector& box, const Vector& a, double b);
+
+	/**
+	 * \brief The system
+	 */
+	const System& sys;
+
+	/**
+	 * \brief Number of (real-valued) constraints
+	 */
+	int m;
+
+	/**
+	 * \brief Goal constraint (in case of extended system, -1 otherwise).
+	 */
+	const int goal_ctr;
+	/**
+	 * Current LP solver
+	 */
+	LPSolver* lp_solver;
+	/*
+	 * Point policy
+	 */
+	point_policy point;
+};
+
+} // end namespace ibex
+
+#endif /* __IBEX_LINEARIZER_ABS_TAYLOR__ */

--- a/src/numeric/ibex_LinearizerXTaylor.cpp
+++ b/src/numeric/ibex_LinearizerXTaylor.cpp
@@ -78,7 +78,7 @@ int LinearizerXTaylor::linearize(const IntervalVector& box, LPSolver& _lp_solver
 
 int LinearizerXTaylor::linearize(const IntervalVector& box, LPSolver& _lp_solver, BoxProperties& prop) {
 	lp_solver = &_lp_solver;
-
+	lp_solver->set_bounds(box);
 	// ========= get active constraints ===========
 	BitSet* active;
 


### PR DESCRIPTION
Hi Gilles,

We have incorporated the AbsTaylor upperbounding/linearization methods and the Iterative loupfinder into the last version of Ibex.

[AbsTaylor](https://link.springer.com/article/10.1007/s10898-020-00878-z) is a linearization method that can use any point inside the box as an expansion point for constructing a inner polytope (by default the midpoint of the box). This feature enables the method to find more upperbounds than its counterpart (XTaylor). It can be used through the new class LoupFinderIP (Loup Finder Inner Polytope). We replaced the class LoupFinderXTaylor by LoupFinderIP. By default, LoupFinderIP uses XTaylor as inner-linearization, thus it is equivalent to the old LoupFinderXTaylor class.

Additionally, the new loupfinder Iterative performs a local search. Starting from an initial point (e.g., the midpoint of the current box), LoupFinderIterative first attempts to find a candidate feasible solution by using AbsTaylor (or XTaylor) and Simplex. If it is successful, then the algorithm performs a loop while the candidate solution is improved. This method gives good results compared to X-Taylor. The “best” parameters found for this method have also been included in the .h as default.

Finally, there is also the source abstaylor.cpp inside the example folder in order to test/check things.

Summarizing, we have included the files:
`examples/abstaylor.cpp`
`src/loup/LoupFinderIP.h`
`src/loup/LoupFinderIP.cpp`
`src/loup/LoupFinderIterative.h`
`src/loup/LoupFinderIterative.cpp`
`src/numeric/ibex_LinearizerAbsTaylor.cpp`
`src/numeric/ibex_LinearizerAbsTaylor.h`

Regards,

Victor Reyes, Ignacio Araya.