### PR TITLE
add cstdint include

### DIFF
--- a/src/data/ibex_Cov.cpp
+++ b/src/data/ibex_Cov.cpp
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <cassert>
 #include <string.h>
+#include <cstdint>
 
 using namespace std;
 

--- a/src/data/ibex_Cov.h
+++ b/src/data/ibex_Cov.h
@@ -17,6 +17,7 @@
 #include <vector>
 #include <fstream>
 #include <stack>
+#include <cstdint>
 
 namespace ibex {
 


### PR DESCRIPTION
without those includes, I get errors when compiling:
```
ibex_Cov.h:106:53: error: ‘uint32_t’ has not been declared
  106 |         static void write_pos_int(std::ofstream& f, uint32_t x);

ibex_Cov.cpp:138:9: error: ‘uint32_t’ was not declared in this scope
  138 |         uint32_t x;  
 ```