### PR TITLE
Compilation issue of Ibex-lib on gwin64-7.3.0

### DIFF
--- a/interval_lib_wrapper/filib/CMakeLists.txt
+++ b/interval_lib_wrapper/filib/CMakeLists.txt
@@ -5,8 +5,8 @@ set (FILIB_NAME ${FILIB_NAME} PARENT_SCOPE)
 include (FindFilib.cmake)
 
 # Avoid overflowing display with warnings
-if (WIN32)
-	add_compile_options("/wd4244")
+if (MSVC)
+	add_compile_options("/wd4244") # disable warning conversion from 'double' to '___', possible loss of data
 else ()
 	add_compile_options(-w)
 endif ()

--- a/interval_lib_wrapper/filib/CMakeLists.txt
+++ b/interval_lib_wrapper/filib/CMakeLists.txt
@@ -5,7 +5,7 @@ set (FILIB_NAME ${FILIB_NAME} PARENT_SCOPE)
 include (FindFilib.cmake)
 
 # Avoid overflowing display with warnings
-if (MSVC)
+if (MSVC) # [#573]
 	add_compile_options("/wd4244") # disable warning conversion from 'double' to '___', possible loss of data
 else ()
 	add_compile_options(-w)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ if (WIN32)
   target_compile_options (ibex PUBLIC "-U__STRICT_ANSI__")
 endif ()
 
-if (WIN32)
+if (MSVC)
 	target_compile_options (ibex PUBLIC "/wd4267" "/wd4244" "/wd4800" "/wd4018" "/wd4101" "/wd4715" "/wd4996" "/wd4065")
 else ()
 	target_compile_options (ibex PUBLIC "-Wno-unknown-pragmas" "-Wno-undefined-var-template") # last warning appears with Filib on MacOS


### PR DESCRIPTION
https://al.liammig.bzh/ibex/ftq/#IBX_VR_000001

As "/wd4244" compilation option is MSVC specific, the current solution only authorize MSVC compilation chain on Windows. This explain why compilation failed with MinGW64 tool chain.

The correction allows MinGW64 and keeps the same behavior for MSVC tool chain.